### PR TITLE
Added color cuts to CLF test

### DIFF
--- a/validation_code/ConditionalLuminosityFunction.py
+++ b/validation_code/ConditionalLuminosityFunction.py
@@ -88,7 +88,8 @@ class ConditionalLuminosityFunction(BaseValidationTest):
                               absolute_magnitude2_field, 'redshift_true'))
             
         cen_query = GCRQuery('is_central') & red_query
-        sat_query = (~cen_query) & red_query
+        sat_query = ~GCRQuery('is_central') & red_query
+
 
         if 'r_host' in quantities_needed and 'r_vir' in quantities_needed:
             sat_query &= GCRQuery('r_host < r_vir')

--- a/validation_configs/CLF_r.yaml
+++ b/validation_configs/CLF_r.yaml
@@ -1,2 +1,4 @@
 subclass_name: ConditionalLuminosityFunction
-band: r
+band2: r
+band1: g
+color_cut_percent : 0.2


### PR DESCRIPTION
I've included a color cut, where the cut is determined by finding the rest frame g-r color which gives the same number density (for z<0.2) for each catalog. This isn't totally optimal, but it's the best solution until we have catalogs with the same bands.