### PR TITLE
Move all DESC-related web setting to config.py

### DIFF
--- a/descqaweb/config.py
+++ b/descqaweb/config.py
@@ -1,10 +1,22 @@
 from __future__ import unicode_literals
 
-__all__ = ['site_title', 'root_dir', 'version_info', 'static_dir', 'run_per_page']
+__all__ = ['site_title', 'root_dir', 'general_info', 'static_dir', 'run_per_page', 'logo_filename', 'github_url']
 
 root_dir = '/global/projecta/projectdirs/lsst/groups/CS/descqa/run/v2'
 site_title = 'DESCQA (v2): LSST DESC Quality Assurance for Galaxy Catalogs'
-version_info = 'This is DESCQA v2. You can also visit the previous version, <a class="everblue" href="https://portal.nersc.gov/project/lsst/descqa/v1/">DESCQA v1</a>.'
+
+run_per_page = 20
 
 static_dir = 'web-static'
-run_per_page = 20
+logo_filename = 'desc-logo-small.png'
+github_url = 'https://github.com/lsstdesc/descqa'
+
+general_info = '''
+This is DESCQA v2. You can also visit the previous version, <a class="everblue" href="https://portal.nersc.gov/project/lsst/descqa/v1/">DESCQA v1</a>.
+<br>
+The DESCQA framework executes validation tests on mock galaxy catalogs.
+These tests and catalogs are contributed by LSST DESC collaborators.
+See <a href="https://arxiv.org/abs/1709.09665" target="_blank">the DESCQA paper</a> for more information.
+Full details about the catalogs and tests, and how to contribute, are available <a href="https://confluence.slac.stanford.edu/x/Z0uKDQ" target="_blank">here</a> (collaborators only).
+The source code of DESCQA is hosted in <a href="https://github.com/LSSTDESC/descqa/" target="_blank">this GitHub repo</a>.
+'''

--- a/descqaweb/config.py
+++ b/descqaweb/config.py
@@ -13,7 +13,7 @@ github_url = 'https://github.com/lsstdesc/descqa'
 
 general_info = '''
 This is DESCQA v2. You can also visit the previous version, <a class="everblue" href="https://portal.nersc.gov/project/lsst/descqa/v1/">DESCQA v1</a>.
-<br>
+<br><br>
 The DESCQA framework executes validation tests on mock galaxy catalogs.
 These tests and catalogs are contributed by LSST DESC collaborators.
 See <a href="https://arxiv.org/abs/1709.09665" target="_blank">the DESCQA paper</a> for more information.

--- a/descqaweb/matrix.py
+++ b/descqaweb/matrix.py
@@ -51,7 +51,7 @@ def prepare_matrix(run=None, catalog_prefix=None, test_prefix=None):
 
     data = dict()
 
-    data['version_info'] = config.version_info
+    data['general_info'] = config.general_info
     data['run'] = descqa_run.name
     data['comment'] = cgi.escape(descqa_run.status.get('comment', ''))
     data['user'] = descqa_run.status.get('user', 'UNKNOWN')

--- a/descqaweb/templates/header.html
+++ b/descqaweb/templates/header.html
@@ -4,7 +4,7 @@
 <title>{{ config.site_title }}</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css">
 <link rel="stylesheet" href="{{ config.static_dir }}/style.css">
 </head>
 
@@ -13,7 +13,7 @@
 {% if full_header %}
 <header>
 <a href="." title="Home" rel="home" id="logo" target="_top">
-<img src="{{ config.static_dir }}/desc-logo-small.png" alt="Home" />
+<img src="{{ config.static_dir }}/{{ config.logo_filename }}" alt="Home" />
 </a>
 </header>
 
@@ -24,7 +24,7 @@
 <div style="float:right; padding-right:0.5em">
 <a class="everblue" href="." target="_top">Latest Run</a>&nbsp;|&nbsp;
 <a class="everblue" href="?run=all" target="_top">All Runs</a>&nbsp;|&nbsp;
-<a class="everblue" href="https://github.com/LSSTDESC/descqa" target="_blank">GitHub</a>
+<a class="everblue" href="{{ config.github_url }}" target="_blank">GitHub</a>
 </div>
 
 <div style="clear:both"></div>

--- a/descqaweb/templates/matrix.html
+++ b/descqaweb/templates/matrix.html
@@ -1,5 +1,5 @@
 <div class="homeinfo">
-<h3>{{ version_info }}</h3>
+<h3>{{ general_info }}</h3>
 <h3>
 The DESCQA framework executes validation tests on mock galaxy catalogs.
 These tests and catalogs are contributed by LSST DESC collaborators.


### PR DESCRIPTION
This PR moves all DESC-related web setting to config.py, so that it will be easier for other people (e.g. DESI) to use and configure the web interface. 