### PR TITLE
update readiness test (add SED, acceptable ranges, relation checking)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 - nosetests
 - python -c "import descqaweb"
 - python -c "import descqarun"
-- '[ -z "$CHANGED" ] || pylint --disable=C0103,C0301 --extension-pkg-whitelist=numpy $CHANGED'
+- '[ -z "$CHANGED" ] || pylint --disable=C0103,C0301 --extension-pkg-whitelist=numpy $CHANGED; EXITCODE=$?; if [ $(($EXITCODE&7)) -gt 0 ]; then exit $EXITCODE; fi;'

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -137,6 +137,10 @@ quantities_to_check:
     f_zero: 0
     f_outlier: [0, 0.05]
 
+  - quantities: 'stellar_mass*'
+    log: true
+    f_nan: 0
+
   - quantities: 'sed_*_*[0123456789]'
     label: SED
     log: true
@@ -144,21 +148,33 @@ quantities_to_check:
     max: [9, 11]
     mean: [5, 8]
     median: [5, 8]
-    std: [0.5, 0.7]
+    std: [0.5, 1.3]
     f_nan: 0
     f_inf: 0
     f_zero: 0
     f_outlier: [0, 0.03]
 
   - quantities: 'sed_*_*_disk'
-    label: SED
+    label: Disk SED
     log: true
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.03]
 
   - quantities: 'sed_*_*_bulge'
-    label: SED
+    label: Bulge SED 
     log: true
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.03]
 
 
 relations_to_check:
  - 'size_minor_bulge_true <= size_bulge_true'
  - 'size_minor_disk_true <= size_disk_true'
+ - '(size_bulge_true != 0) | (stellar_mass_bulge == 0)'
+ - 'stellar_mass_bulge <= stellar_mass'
+ - 'stellar_mass_disk <= stellar_mass'
+

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -85,23 +85,24 @@ quantities_to_check:
     f_outlier: 0
 
   - quantities: 'convergence'
-    min: [0, 0.001]
-    max: [0, 1]
-    median: [0, 0.1]
-    mean: [0, 0.1]
-    std: [0, 0.1]
+    min: [-0.3, 0]
+    max: [0, 0.3]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.02]
     f_nan: 0
     f_inf: 0
-    f_outlier: [0, 0.01]
+    f_outlier: [0, 0.03]
 
   - quantities: 'magnification'
-    min: [0, 0.001]
+    min: [0.5, 1]
     max: [1, 2]
     median: [0.5, 1.5]
     mean: [0.5, 1.5]
     std: [0, 0.1]
     f_nan: 0
     f_inf: 0
+    f_outlier: [0, 0.03]
 
   - quantities: 'sersic_disk'
     min: 1
@@ -167,7 +168,7 @@ quantities_to_check:
     f_outlier: [0, 0.1]
 
   - quantities: 'sed_*_*_bulge'
-    label: Bulge SED 
+    label: Bulge SED
     log: true
     min: [-12.0, -7.0]
     max: [9, 11]
@@ -179,14 +180,40 @@ quantities_to_check:
     f_outlier: [0, 0.03]
 
   - quantities: A_v
+    min: [0.001, 3.1]
+    max: [0.001, 3.1]
+    median: [0.001, 3.1]
+    mean: [0.001, 3.1]
+    f_nan: 0
+    f_inf: 0
 
   - quantities: R_v
+    min: [1, 5]
+    max: [1, 5]
+    median: [1, 5]
+    mean: [1, 5]
+    f_nan: 0
+    f_inf: 0
 
+  - quantities: bulge_to_total_ratio*
+    min: [0, 1]
+    max: [0, 1]
+    median: [0, 1]
+    mean: [0, 1]
+    f_nan: 0
+    f_inf: 0
 
 relations_to_check:
   - 'size_minor_bulge_true <= size_bulge_true'
   - 'size_minor_disk_true <= size_disk_true'
+  - 'size_minor_true <= size_true'
   - '(size_bulge_true != 0) | (stellar_mass_bulge == 0)'
   - 'stellar_mass_bulge <= stellar_mass'
   - 'stellar_mass_disk <= stellar_mass'
-  - '1.0 / magnification == (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'
+  - ['1.0 / magnification', '(1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0']
+  - ['size_minor_true / size_true', '(1.0 - ellipticity_true) / (1.0 + ellipticity_true)']
+  - ['size_minor_disk_true / size_disk_true', '(1.0 - ellipticity_disk_true) / (1.0 + ellipticity_disk_true)']
+  - ['size_minor_bulge_true / size_bulge_true', '(1.0 - ellipticity_bulge_true) / (1.0 + ellipticity_bulge_true)']
+  - ['ellipticity_1_true ** 2.0 + ellipticity_2_true ** 2.0', 'ellipticity_true ** 2.0']
+  - ['ellipticity_1_disk_true ** 2.0 + ellipticity_2_disk_true ** 2.0', 'ellipticity_disk_true ** 2.0']
+  - ['ellipticity_1_bulge_true ** 2.0 + ellipticity_2_bulge_true ** 2.0', 'ellipticity_bulge_true ** 2.0']

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -184,9 +184,9 @@ quantities_to_check:
 
 
 relations_to_check:
- - 'size_minor_bulge_true <= size_bulge_true'
- - 'size_minor_disk_true <= size_disk_true'
- - '(size_bulge_true != 0) | (stellar_mass_bulge == 0)'
- - 'stellar_mass_bulge <= stellar_mass'
- - 'stellar_mass_disk <= stellar_mass'
-
+  - 'size_minor_bulge_true <= size_bulge_true'
+  - 'size_minor_disk_true <= size_disk_true'
+  - '(size_bulge_true != 0) | (stellar_mass_bulge == 0)'
+  - 'stellar_mass_bulge <= stellar_mass'
+  - 'stellar_mass_disk <= stellar_mass'
+  - '1.0 / magnification == (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -49,13 +49,20 @@ quantities_to_check:
   - quantities: 'size*'
     label: size
     log: true
+    min: [-6, -4]
+    max: [1, 3]
+    median: [-2, 0]
+    mean: [-2, 0]
+    std: [0.1, 0.5]
     f_nan: 0
+    f_zero: 0
     f_inf: [0, 0.3]
-    f_outlier: [0, 0.3]
+    f_outlier: [0, 0.01]
 
   - quantities: size*_bulge*
     f_nan: 0
     f_inf: 0
+    min: [0, null]
 
   - quantities: 'shear_*'
     min: [-0.1, 0]
@@ -72,13 +79,29 @@ quantities_to_check:
     max: [179.99, 180]
     median: [89.9, 90.1]
     mean: [89.9, 90.1]
+    std: [0, 90.0]
     f_nan: 0
     f_inf: 0
     f_outlier: 0
 
   - quantities: 'convergence'
+    min: [0, 0.001]
+    max: [0, 1]
+    median: [0, 0.1]
+    mean: [0, 0.1]
+    std: [0, 0.1]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.01]
 
   - quantities: 'magnification'
+    min: [0, 0.001]
+    max: [1, 2]
+    median: [0.5, 1.5]
+    mean: [0.5, 1.5]
+    std: [0, 0.1]
+    f_nan: 0
+    f_inf: 0
 
   - quantities: 'sersic_disk'
     min: 1
@@ -113,3 +136,21 @@ quantities_to_check:
     f_inf: 0
     f_zero: 0
     f_outlier: [0, 0.05]
+
+  - quantities: 'SEDs/totalLuminositiesStellar*:rest'
+    label: SED
+    log: true
+    min: [2, 7]
+    max: [9, 11]
+    mean: [5, 8]
+    median: [5, 8]
+    std: [0.5, 0.7]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.03]
+
+
+relations_to_check:
+ - 'size_minor_bulge_true <= size_bulge_true'
+ - 'size_minor_disk_true <= size_disk_true'

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -157,18 +157,30 @@ quantities_to_check:
   - quantities: 'sed_*_*_disk'
     label: Disk SED
     log: true
+    min: [-23.0, -20.0]
+    max: [9, 10]
+    median: [5, 7]
+    mean: [5, 7]
+    std: [1, 2]
     f_nan: 0
-    f_inf: 0
     f_zero: 0
-    f_outlier: [0, 0.03]
+    f_outlier: [0, 0.1]
 
   - quantities: 'sed_*_*_bulge'
     label: Bulge SED 
     log: true
+    min: [-12.0, -7.0]
+    max: [9, 11]
+    median: [3, 7]
+    mean: [3, 7]
+    std: [0.5, 1.5]
     f_nan: 0
-    f_inf: 0
     f_zero: 0
     f_outlier: [0, 0.03]
+
+  - quantities: A_v
+
+  - quantities: R_v
 
 
 relations_to_check:

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -140,7 +140,13 @@ quantities_to_check:
 
   - quantities: 'stellar_mass*'
     log: true
+    min: [null, 10]
+    max: [10, 13]
+    median: [7.5, 9]
+    mean: [7.5, 9]
+    std: [0.5, 1.5]
     f_nan: 0
+    f_outlier: [0, 0.02]
 
   - quantities: 'sed_*_*[0123456789]'
     label: SED

--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -137,7 +137,7 @@ quantities_to_check:
     f_zero: 0
     f_outlier: [0, 0.05]
 
-  - quantities: 'SEDs/totalLuminositiesStellar*:rest'
+  - quantities: 'sed_*_*[0123456789]'
     label: SED
     log: true
     min: [2, 7]
@@ -149,6 +149,14 @@ quantities_to_check:
     f_inf: 0
     f_zero: 0
     f_outlier: [0, 0.03]
+
+  - quantities: 'sed_*_*_disk'
+    label: SED
+    log: true
+
+  - quantities: 'sed_*_*_bulge'
+    label: SED
+    log: true
 
 
 relations_to_check:

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -24,6 +24,11 @@ def calc_frac(x, func, total=None):
     total = total or len(x)
     return np.count_nonzero(func(x)) / total
 
+
+def split_for_natural_sort(s):
+    return tuple((int(y) if y.isdigit() else y for y in re.split(r'(\d+)', s)))
+
+
 class CheckQuantities(BaseValidationTest):
     """
     Readiness test to check catalog quantities before image simulations
@@ -57,10 +62,6 @@ class CheckQuantities(BaseValidationTest):
         output.append('</tr>')
         return ''.join(output)
 
-    def stringSplitByIntegers(self,x):
-        r = re.compile('(\d+)')
-        l = r.split(x)
-        return [int(y) if y.isdigit() else y for y in l]
 
     def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
 
@@ -88,7 +89,7 @@ class CheckQuantities(BaseValidationTest):
                 failed_count += 1
                 continue
 
-            quantities_this = sorted(quantities_this, key=self.stringSplitByIntegers)
+            quantities_this = sorted(quantities_this, key=split_for_natural_sort)
 
             if 'label' in checks:
                 quantity_group_label = checks['label']

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -24,7 +24,6 @@ def calc_frac(x, func, total=None):
     total = total or len(x)
     return np.count_nonzero(func(x)) / total
 
-
 class CheckQuantities(BaseValidationTest):
     """
     Readiness test to check catalog quantities before image simulations
@@ -58,6 +57,10 @@ class CheckQuantities(BaseValidationTest):
         output.append('</tr>')
         return ''.join(output)
 
+    def stringSplitByIntegers(self,x):
+        r = re.compile('(\d+)')
+        l = r.split(x)
+        return [int(y) if y.isdigit() else y for y in l]
 
     def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
 
@@ -84,6 +87,8 @@ class CheckQuantities(BaseValidationTest):
                 output_header.append('<span class="fail">Found no matching quantities for {}</span>'.format(quantity_pattern))
                 failed_count += 1
                 continue
+
+            quantities_this = sorted(quantities_this, key=self.stringSplitByIntegers)
 
             if 'label' in checks:
                 quantity_group_label = checks['label']
@@ -199,3 +204,4 @@ class CheckQuantities(BaseValidationTest):
             f.write('</tbody></table></body></html>\n')
 
         return TestResult(passed=(failed_count == 0), score=failed_count)
+

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -53,6 +53,7 @@ class CheckQuantities(BaseValidationTest):
         assert all('quantities' in d for d in self.quantities_to_check), 'yaml file not correctly specified'
         self.nbins = kwargs.get('nbins', 50)
         self.prop_cycle = cycle(iter(plt.rcParams['axes.prop_cycle']))
+        super(CheckQuantities, self).__init__(**kwargs)
 
 
     def _format_row(self, quantity, plot_filename, results):
@@ -81,6 +82,7 @@ class CheckQuantities(BaseValidationTest):
             assert quantity_patterns, 'yaml file not specify correctly!'
 
             quantities_this = set()
+            quantity_pattern = None
             for quantity_pattern in quantity_patterns:
                 quantities_this.update(fnmatch.filter(all_quantities, quantity_pattern))
 
@@ -173,7 +175,7 @@ class CheckQuantities(BaseValidationTest):
 
             try:
                 result = ne.evaluate(relation, local_dict=catalog_instance.get_quantities(quantities_needed), global_dict={}).all()
-            except Exception:
+            except Exception: # pylint: disable=broad-except
                 output_header.append('<span class="fail">Not able to evaluate `{}`!</span>'.format(relation))
                 failed_count += 1
                 continue


### PR DESCRIPTION
This PR updates the readiness test for protoDC2 with the following features:
- including SEDs (fixes #64)
- add more acceptable ranges (fixes #60)
- add a new feature to do simple relation checking

➡️ [Click here to see the test result from this PR](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-01-24_2&test=readiness_protoDC2&right=2018-01-24_2/readiness_protoDC2/protoDC2/SUMMARY.html) 

Can @evevkovacs @dkorytov @abensonca comment on whether the results look good? Currently the catalog is failing because some of the SED std is too big, but if that's normal we can change the acceptable ranges. 

Also, any other simple relations we should include? I only added two as a test. 