### PR TITLE
Update v1 catalog register

### DIFF
--- a/v1/GCRCatalogs/__init__.py
+++ b/v1/GCRCatalogs/__init__.py
@@ -2,4 +2,4 @@
 DESCQA v1 reader interface
 """
 from .register import *
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/v1/GCRCatalogs/register.py
+++ b/v1/GCRCatalogs/register.py
@@ -4,7 +4,7 @@ import yaml
 from .config import base_catalog_dir
 
 
-__all__ = ['available_catalogs', 'get_available_catalogs', 'load_catalog']
+__all__ = ['available_catalogs', 'get_catalog_config', 'get_available_catalogs', 'load_catalog']
 
 
 def load_yaml(yaml_file):
@@ -25,6 +25,13 @@ def import_subclass(subclass, package=None, required_base_class=None):
     if required_base_class:
         assert issubclass(subclass, required_base_class), "Provided class is not a subclass of *required_base_class*"
     return subclass
+
+
+def get_catalog_config(catalog):
+    """
+    get the config dict of *catalog*
+    """
+    return available_catalogs[catalog]
 
 
 def get_available_configs(config_dir, register=None):


### PR DESCRIPTION
This is a patch to the v1 reader (adding `get_catalog_config`) so that it continue to work with the updated `descqarun`. 