### PR TITLE
use ~== for "all-close" relation in readiness test

### DIFF
--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -216,10 +216,10 @@ relations_to_check:
   - '(size_bulge_true != 0) | (stellar_mass_bulge == 0)'
   - 'stellar_mass_bulge <= stellar_mass'
   - 'stellar_mass_disk <= stellar_mass'
-  - ['1.0 / magnification', '(1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0']
-  - ['size_minor_true / size_true', '(1.0 - ellipticity_true) / (1.0 + ellipticity_true)']
-  - ['size_minor_disk_true / size_disk_true', '(1.0 - ellipticity_disk_true) / (1.0 + ellipticity_disk_true)']
-  - ['size_minor_bulge_true / size_bulge_true', '(1.0 - ellipticity_bulge_true) / (1.0 + ellipticity_bulge_true)']
-  - ['ellipticity_1_true ** 2.0 + ellipticity_2_true ** 2.0', 'ellipticity_true ** 2.0']
-  - ['ellipticity_1_disk_true ** 2.0 + ellipticity_2_disk_true ** 2.0', 'ellipticity_disk_true ** 2.0']
-  - ['ellipticity_1_bulge_true ** 2.0 + ellipticity_2_bulge_true ** 2.0', 'ellipticity_bulge_true ** 2.0']
+  - '1.0 / magnification ~== (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'
+  - 'size_minor_true / size_true ~== (1.0 - ellipticity_true) / (1.0 + ellipticity_true)'
+  - 'size_minor_disk_true / size_disk_true ~== (1.0 - ellipticity_disk_true) / (1.0 + ellipticity_disk_true)'
+  - 'size_minor_bulge_true / size_bulge_true ~== (1.0 - ellipticity_bulge_true) / (1.0 + ellipticity_bulge_true)'
+  - 'ellipticity_1_true ** 2.0 + ellipticity_2_true ** 2.0 ~== ellipticity_true ** 2.0'
+  - 'ellipticity_1_disk_true ** 2.0 + ellipticity_2_disk_true ** 2.0 ~== ellipticity_disk_true ** 2.0'
+  - 'ellipticity_1_bulge_true ** 2.0 + ellipticity_2_bulge_true ** 2.0 ~== ellipticity_bulge_true ** 2.0'

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -187,29 +187,29 @@ class CheckQuantities(BaseValidationTest):
                 failed_count += 1
 
         for relation in self.relations_to_check:
-            if isinstance(relation, (tuple, list)):
-                assert len(relation) == 2, '`relation` must a single string or a list of *two* strings.'
-                func = lambda r: np.allclose(
-                    evaluate_expression(r[0], catalog_instance),
-                    evaluate_expression(r[1], catalog_instance),
+            expr1, simeq, expr2 = relation.partition('~==')
+            if simeq:
+                expr1 = expr1.strip()
+                expr2 = expr2.strip()
+                func = lambda: np.allclose(
+                    evaluate_expression(expr1, catalog_instance),
+                    evaluate_expression(expr2, catalog_instance),
                     equal_nan=True
                 )
-                relation_expr = '{} ~~ {}'.format(*relation)
             else:
-                func = lambda r: evaluate_expression(r, catalog_instance).all()
-                relation_expr = relation
+                func = lambda: evaluate_expression(relation, catalog_instance).all()
 
             try:
-                result = func(relation)
+                result = func()
             except Exception as e: # pylint: disable=broad-except
-                output_header.append('<span class="fail">Not able to evaluate `{}`! {}</span>'.format(relation_expr, e))
+                output_header.append('<span class="fail">Not able to evaluate `{}`! {}</span>'.format(relation, e))
                 failed_count += 1
                 continue
 
             if result:
-                output_header.append('<span>It is true that `{}`</span>'.format(relation_expr))
+                output_header.append('<span>It is true that `{}`</span>'.format(relation))
             else:
-                output_header.append('<span class="fail">`{}` not true!</span>'.format(relation_expr))
+                output_header.append('<span class="fail">`{}` not true!</span>'.format(relation))
                 failed_count += 1
 
         with open(os.path.join(output_dir, 'SUMMARY.html'), 'w') as f:

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -189,15 +189,13 @@ class CheckQuantities(BaseValidationTest):
         for relation in self.relations_to_check:
             expr1, simeq, expr2 = relation.partition('~==')
             if simeq:
-                expr1 = expr1.strip()
-                expr2 = expr2.strip()
-                func = lambda: np.allclose(
-                    evaluate_expression(expr1, catalog_instance),
-                    evaluate_expression(expr2, catalog_instance),
+                func = lambda e1=expr1.strip(), e2=expr2.strip(): np.allclose(
+                    evaluate_expression(e1, catalog_instance),
+                    evaluate_expression(e2, catalog_instance),
                     equal_nan=True
                 )
             else:
-                func = lambda: evaluate_expression(relation, catalog_instance).all()
+                func = lambda r=relation: evaluate_expression(r, catalog_instance).all()
 
             try:
                 result = func()


### PR DESCRIPTION
This PR allows the use of `~==` in the relations to check in the readiness test. It means "all close" (by using the `np.allclose` function). Useful to comparing float-point quantities. 