### PR TITLE
Remove CFHTLS-wide objects from color distribution

### DIFF
--- a/descqa/ColorDistribution.py
+++ b/descqa/ColorDistribution.py
@@ -84,9 +84,11 @@ class ColorDistribution(BaseValidationTest):
         mask &= (obscat[obs_zcol] > self.zlo) & (obscat[obs_zcol] < self.zhi)
         obscat = obscat[mask]
 
-        # Remove unsecured redshifts from DEEP2
         if self.validation_catalog == 'DEEP2':
+            # Remove unsecured redshifts
             mask = obscat['zquality'] >= 3
+            # Remove CFHTLS-Wide objects
+            mask &= obscat['cfhtls_source']==0
             obscat = obscat[mask]
 
         # Selection weights

--- a/descqa/ColorDistribution.py
+++ b/descqa/ColorDistribution.py
@@ -88,7 +88,7 @@ class ColorDistribution(BaseValidationTest):
             # Remove unsecured redshifts
             mask = obscat['zquality'] >= 3
             # Remove CFHTLS-Wide objects
-            mask &= obscat['cfhtls_source']==0
+            mask &= obscat['cfhtls_source'] == 0
             obscat = obscat[mask]
 
         # Selection weights


### PR DESCRIPTION
This PR fixes a bug in the color distribution test that allowed the much shallower CFHTLS Wide field photometry to be included for calculating the color distribution. It now requires that only the CFHTLS Deep field photometry be used.