### PR TITLE
Added galaxyID assert, optional plot ranges and check of Mag*

### DIFF
--- a/descqa/configs/readiness_protoDC2.yaml
+++ b/descqa/configs/readiness_protoDC2.yaml
@@ -59,11 +59,15 @@ quantities_to_check:
     f_zero: 0
     f_inf: [0, 0.3]
     f_outlier: [0, 0.01]
+    plot_min: -3
+    plot_max: 1
 
   - quantities: size*_bulge*
     f_nan: 0
     f_inf: 0
     min: [0, null]
+    plot_min: 0
+    plot_max: 3
 
   - quantities: 'shear_*'
     min: [-0.2, 0]
@@ -139,6 +143,18 @@ quantities_to_check:
     f_zero: 0
     f_outlier: [0, 0.05]
 
+  - quantities: 'Mag_*lsst*'
+    label: Mag
+    min: [null, -23]
+    max: [-12, null]
+    mean: [-17, -8]
+    median: [-17, -8]
+    std: [0, 5]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.05]
+
   - quantities: 'stellar_mass*'
     log: true
     min: [null, 10]
@@ -193,6 +209,8 @@ quantities_to_check:
     mean: [0.001, 3.1]
     f_nan: 0
     f_inf: 0
+    plot_min: -0.2
+    plot_max: 3
 
   - quantities: R_v
     min: [1, 5]
@@ -201,6 +219,7 @@ quantities_to_check:
     mean: [1, 5]
     f_nan: 0
     f_inf: 0
+    plot_min: -0.5
 
   - quantities: bulge_to_total_ratio*
     min: [0, 1]
@@ -211,6 +230,7 @@ quantities_to_check:
     f_inf: 0
 
 relations_to_check:
+  - 'galaxyID <= 9e10'
   - 'size_minor_bulge_true <= size_bulge_true'
   - 'size_minor_disk_true <= size_disk_true'
   - 'size_minor_true <= size_true'
@@ -220,7 +240,7 @@ relations_to_check:
   - '1.0 / magnification ~== (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'
   - 'size_minor_true / size_true ~== (1.0 - ellipticity_true) / (1.0 + ellipticity_true)'
   - 'size_minor_disk_true / size_disk_true ~== (1.0 - ellipticity_disk_true) / (1.0 + ellipticity_disk_true)'
-  - 'size_minor_bulge_true / size_bulge_true ~== (1.0 - ellipticity_bulge_true) / (1.0 + ellipticity_bulge_true)'
+  - 'size_minor_bulge_true ~== size_bulge_true * (1.0 - ellipticity_bulge_true) / (1.0 + ellipticity_bulge_true)'
   - 'ellipticity_1_true ** 2.0 + ellipticity_2_true ** 2.0 ~== ellipticity_true ** 2.0'
   - 'ellipticity_1_disk_true ** 2.0 + ellipticity_2_disk_true ** 2.0 ~== ellipticity_disk_true ** 2.0'
   - 'ellipticity_1_bulge_true ** 2.0 + ellipticity_2_bulge_true ** 2.0 ~== ellipticity_bulge_true ** 2.0'

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -118,7 +118,7 @@ class CheckQuantities(BaseValidationTest):
         for i, checks in enumerate(self.quantities_to_check):
 
             quantity_patterns = checks['quantities'] if isinstance(checks['quantities'], (tuple, list)) else [checks['quantities']]
-            assert quantity_patterns, 'yaml file not specify correctly!'
+            assert quantity_patterns, 'yaml file not correctly specified!'
 
             quantities_this = set()
             quantity_pattern = None
@@ -191,6 +191,10 @@ class CheckQuantities(BaseValidationTest):
 
             ax.set_xlabel(('log ' if checks.get('log') else '') + quantity_group_label)
             ax.yaxis.set_ticklabels([])
+            if checks.get('plot_min') is not None: #zero values fail otherwise
+                ax.set_xlim(left=checks.get('plot_min'))
+            if checks.get('plot_max') is not None:
+                ax.set_xlim(right=checks.get('plot_max'))
             ax.set_title('{} {}'.format(catalog_name, getattr(catalog_instance, 'version', '')), fontsize='small')
             fig.tight_layout()
             if len(quantities_this) <= 9:


### PR DESCRIPTION
> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 

Made some updates to the readiness test (maximum galaxyID check, change on size_bulge_minor check, added optional plot ranges, added Mag* distributions)
https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-04-10_7&catalog=proto-dc2_v4.0_test