### PR TITLE
Added jackknife errors and turned on as default test

### DIFF
--- a/descqa/configs/Nz_i_Coil2004_magbin.yaml
+++ b/descqa/configs/Nz_i_Coil2004_magbin.yaml
@@ -3,5 +3,8 @@ band: i
 zlo: 0.
 zhi: 1.0
 Nbins: 20
+jackknife: True
+N_jack: 10
 observation: 'Coil2004_magbin'
+included_by_default: true
 description: 'Plot N(z) distributions for selected magnitude cuts in specified band and compare with fits to DEEP2 data from Coil et. al. (2004).'


### PR DESCRIPTION
> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 

Minor change to yaml file to include jackknife errors for N(z) tomographic magnitude bins and to turn the test on by default (preferred by PZ group). See result:
[]https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-05-18_3