### PR TITLE
Ellipticity validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![DOI](https://zenodo.org/badge/47784041.svg)](https://zenodo.org/badge/latestdoi/47784041)
 [![Paper DOI](https://img.shields.io/badge/Paper%20DOI-10.3847%2F1538--4365%2Faaa6c3-brightgreen.svg)](https://doi.org/10.3847/1538-4365/aaa6c3)
 [![arXiv:1709.09665](https://img.shields.io/badge/astro--ph.IM-arXiv%3A1709.09665-B31B1B.svg)](https://arxiv.org/abs/1709.09665)
+[![ascl:1804.011](https://img.shields.io/badge/ascl-1804.011-blue.svg?colorB=262255)](http://ascl.net/1804.011)
 
 This repository contains the DESCQA framework that validates simulated galaxy catalogs. For more information about this framework, please check out the [DESCQA paper](https://arxiv.org/abs/1709.09665).
 

--- a/descqa/EllipticityDistribution.py
+++ b/descqa/EllipticityDistribution.py
@@ -361,7 +361,7 @@ class EllipticityDistribution(BaseValidationTest):
         #check overall ellipticity distribution
         global_N = np.sum(np.sum(N_array, axis=1), axis=0)
         number_passed, percentiles = self.validate_percentiles(global_N)
-        print("Percentiles for global distribution are:".format(morphology)+', '.join([" {:.3f} ({})".format(p, v) for p,v in zip(percentiles, self.validation_percentiles['percentiles'])]))
+        print("Percentiles for global distribution are: "+', '.join([" {:.3f} ({})".format(p, v) for p,v in zip(percentiles, self.validation_percentiles['percentiles'])]))
         if number_passed>0:
             print("Ellipticity percentile check failed for global distribution")
         n_fails += number_passed

--- a/descqa/EllipticityDistribution.py
+++ b/descqa/EllipticityDistribution.py
@@ -52,8 +52,8 @@ class EllipticityDistribution(BaseValidationTest):
     }
     
     validation_percentiles = {
-        'percentiles': [10, 50, 90, 100],
-        'ranges': [(0, 0.2), (0.35, 0.65), (0.8, 1.0)]
+        'percentiles': [10, 50, 90],
+        'ranges': [(0, 0.4), (0.3, 0.7), (0.6, 1.0)]
     }
 
     #define ellipticity functions
@@ -347,9 +347,10 @@ class EllipticityDistribution(BaseValidationTest):
                 self.decorate_subplot(summary_ax_this, n, label=cutlabel)
                 
                 #check ellipticity distributions
-                number_passed = self.validate_percentiles(N)
+                number_passed, percentiles = self.validate_percentiles(N)
                 if number_passed>0:
-                    print("Ellipticity percentile check failed for morphology {}".format(morphology))
+                    print("Ellipticity percentile check failed for morphology {}:".format(morphology))
+                    print("Percentiles are:"+(" {:.3f}"*len(percentiles)).format(*percentiles))
                 n_fails += number_passed
                 
 
@@ -360,10 +361,10 @@ class EllipticityDistribution(BaseValidationTest):
         
         #check overall ellipticity distribution
         global_N = np.sum(np.sum(N_array, axis=1), axis=0)
-        print(len(global_N), self.N_ebins)
-        number_passed = self.validate_percentiles(global_N)
+        number_passed, percentiles = self.validate_percentiles(global_N)
         if number_passed>0:
             print("Ellipticity percentile check failed for global distribution")
+            print("Percentiles are:"+(" {:.3f}"*len(percentiles)).format(*percentiles))
         n_fails += number_passed
         
 
@@ -440,9 +441,8 @@ class EllipticityDistribution(BaseValidationTest):
         cdf *= 100 # because numpy percentile wants percentages
         interpolator = interp1d(cdf, self.ebins)
         percentiles = interpolator(self.validation_percentiles['percentiles'])
-        print(percentiles, "percentiles")
-        return np.sum([(p>=pmin) & (p<=pmax) for p, (pmin, pmax) in zip(
-                            percentiles, self.validation_percentiles['ranges'])])
+        return np.sum([(p<=pmin) | (p>=pmax) for p, (pmin, pmax) in zip(
+                            percentiles, self.validation_percentiles['ranges'])]), percentiles
             
 
     @staticmethod

--- a/descqa/EllipticityDistribution.py
+++ b/descqa/EllipticityDistribution.py
@@ -290,10 +290,10 @@ class EllipticityDistribution(BaseValidationTest):
                     #check borders
                     if np.min(e_this)<0:
                         any_low = True
-                        print('Value<0 found for morphology {} in catalog {}'.format(morphology, catalog_name))
-                    if np.max(e_this)>0:
+                        print('Value<0 found for morphology {} in catalog {}: {}'.format(morphology, catalog_name, np.min(e_this)))
+                    if np.max(e_this)>1:
                         any_high = True
-                        print('Value<0 found for morphology {} in catalog {}'.format(morphology, catalog_name))
+                        print('Value>1 found for morphology {} in catalog {}: {}'.format(morphology, catalog_name, np.max(e_this)))
 
         #check that catalog has entries for quantity to be plotted
         if not np.asarray([N.sum() for N in N_array]).sum():
@@ -437,14 +437,13 @@ class EllipticityDistribution(BaseValidationTest):
         for i in range(self.N_ebins):
             cdf[i+1:] += data[i]
         cdf /= cdf[-1]
+        cdf *= 100 # because numpy percentile wants percentages
         interpolator = interp1d(cdf, self.ebins)
-        percentiles = interpolator(self.validation_percentiles['percentile'])
+        percentiles = interpolator(self.validation_percentiles['percentiles'])
+        print(percentiles, "percentiles")
         return np.sum([(p>=pmin) & (p<=pmax) for p, (pmin, pmax) in zip(
                             percentiles, self.validation_percentiles['ranges'])])
             
-        
-        
-
 
     @staticmethod
     def post_process_plot(fig):

--- a/descqa/EllipticityDistribution.py
+++ b/descqa/EllipticityDistribution.py
@@ -51,11 +51,6 @@ class EllipticityDistribution(BaseValidationTest):
         },
     }
     
-    validation_percentiles = {
-        'percentiles': [10, 50, 90],
-        'ranges': [(0, 0.4), (0.3, 0.7), (0.6, 1.0)]
-    }
-
     #define ellipticity functions
     @staticmethod
     def e_default(e):
@@ -166,6 +161,10 @@ class EllipticityDistribution(BaseValidationTest):
         #could plot summary validation data here if available but would need to evaluate labels, bin values etc.
         #otherwise setup a check so that validation data is plotted only once on summary plot
         self.first_pass = True
+
+        self.validation_percentiles = {
+            'percentiles': kwargs['validation_percentile_points'],
+            'ranges': kwargs['validation_percentile_ranges']}
 
         self._other_kwargs = kwargs
 
@@ -348,9 +347,9 @@ class EllipticityDistribution(BaseValidationTest):
                 
                 #check ellipticity distributions
                 number_passed, percentiles = self.validate_percentiles(N)
+                print("Percentiles for morphology {} are: ".format(morphology)+', '.join([" {:.3f} ({})".format(p, v) for p,v in zip(percentiles, self.validation_percentiles['percentiles'])]))
                 if number_passed>0:
-                    print("Ellipticity percentile check failed for morphology {}:".format(morphology))
-                    print("Percentiles are:"+(" {:.3f}"*len(percentiles)).format(*percentiles))
+                    print("Ellipticity percentile check failed for morphology {}".format(morphology))
                 n_fails += number_passed
                 
 
@@ -362,9 +361,9 @@ class EllipticityDistribution(BaseValidationTest):
         #check overall ellipticity distribution
         global_N = np.sum(np.sum(N_array, axis=1), axis=0)
         number_passed, percentiles = self.validate_percentiles(global_N)
+        print("Percentiles for global distribution are:".format(morphology)+', '.join([" {:.3f} ({})".format(p, v) for p,v in zip(percentiles, self.validation_percentiles['percentiles'])]))
         if number_passed>0:
             print("Ellipticity percentile check failed for global distribution")
-            print("Percentiles are:"+(" {:.3f}"*len(percentiles)).format(*percentiles))
         n_fails += number_passed
         
 

--- a/descqa/configs/ellipticity_dist.yaml
+++ b/descqa/configs/ellipticity_dist.yaml
@@ -2,4 +2,12 @@ subclass_name: EllipticityDistribution.EllipticityDistribution
 zlo: 0.
 zhi: 2.
 N_ebins: 40
+validation_percentile_points:
+  - 10
+  - 50
+  - 90
+validation_percentile_ranges:
+  - [0, 0.4]
+  - [0.3, 0.7]
+  - [0.6, 1]
 description: 'Plot ellipticity distributions'

--- a/descqa/configs/ellipticity_dist_COSMOS.yaml
+++ b/descqa/configs/ellipticity_dist_COSMOS.yaml
@@ -4,4 +4,12 @@ zhi: 2.
 N_ebins: 40
 observation: 'COSMOS_2013'
 normed: True
+validation_percentile_points:
+  - 10
+  - 50
+  - 90
+validation_percentile_ranges:
+  - [0, 0.4]
+  - [0.3, 0.7]
+  - [0.6, 1]
 description: 'Plot ellipticity distributions and compare with distributions from Joachimi et al 2013 COSMOS data'


### PR DESCRIPTION
This code contains the validation criteria for the ellipticity distribution test.  A run of this test on the v4.* catalogs can be found [here](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-05-29_7).  Everything passes except for the late-type galaxies in proto-dc2_v4.5_rescale, where the 10th percentile is a little high (0.41 instead of <=0.4).  I'm not sure that's actually important--I've left if for now so more knowledgeable people can advise me if that's expected or not. It would probably be okay to adjust that criterion if we needed to, however.

The actual validation criteria used here are:
- min(e)>=0
- max(e)<=1
- 10th percentile < 0.4
- 0.3 < 50th percentile < 0.7
- 90th percentile > 0.6

This is tested for all morphologies separately and for the catalog as a whole; the returned float value is the total number of failed criteria.  The criteria are currently hard-coded but the percentiles could be moved to config files if desired.