### PR TITLE
change clf binning

### DIFF
--- a/descqa/clf_test.py
+++ b/descqa/clf_test.py
@@ -14,8 +14,8 @@ class ConditionalLuminosityFunction(BaseValidationTest):
         self.kwargs = kwargs
         self.band1 = kwargs.get('band1', 'g')
         self.band2 = kwargs.get('band2', 'r')
-        self.magnitude_bins = np.linspace(*kwargs.get('magnitude_bins', (-26, -18, 29)))
-        self.mass_bins = np.logspace(*kwargs.get('mass_bins', (13.5, 15, 5)))
+        self.magnitude_bins = np.linspace(*kwargs.get('magnitude_bins', (-27, -18, 29)))
+        self.mass_bins = 10**np.array((kwargs.get('mass_bins', [13.5, 14.0, 14.5, 15.0, 15.5])))
         self.z_bins = np.linspace(*kwargs.get('z_bins', (0.2, 1.0, 4)))
         self.color_cut_fraction = float(kwargs.get('color_cut_fraction', 0.2))
 

--- a/descqa/configs/CLF_r.yaml
+++ b/descqa/configs/CLF_r.yaml
@@ -4,3 +4,11 @@ band1: g
 color_cut_fraction: 0.2
 description: Conditional luminosity function (in r band) for central and satellite galaxies
 included_by_default: true
+z_bins:
+   - 0.1
+   - 1.0
+   - 3
+mass_bins:
+   - 13.5
+   - 13.7
+   - 15.5


### PR DESCRIPTION
@yymao I changed the mass and redshift binning scheme in clf_test to make the feature at high mass end more noticeable. 
Here is a run on proto-dc2v4.3 and protodc2v4.5. 
https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-05-31_19&test=CLF_r&catalog=proto-dc2_v4.5