### PR TITLE
Size-luminosity validation criteria

### DIFF
--- a/descqa/configs/size_Mandelbaum2014_BD.yaml
+++ b/descqa/configs/size_Mandelbaum2014_BD.yaml
@@ -25,6 +25,7 @@ z_bins:
 fig_xlabel: '$(L/L_{\odot})_{I}$'
 fig_ylabel: '$\log_{10}(R_e)$ (kpc)'
 
+chisq_max: 1.2
 
 description: |
   Compare evolution of bulge and disk sizes as a function of i-band magnitude of LSST and redshift and comparing to Mandelbaum et al (2015) HST COSMOS F814W observations

--- a/descqa/configs/size_vanderWel2014_SM_Lum.yaml
+++ b/descqa/configs/size_vanderWel2014_SM_Lum.yaml
@@ -33,5 +33,7 @@ z_bins:
 fig_xlabel: '$\log_{10}(L/L_{\odot}) [{\rm V-band}]$'
 fig_ylabel: '$\log_{10}(R_e) [{\rm kpc}]$'
 
+chisq_max: 1.2
+
 description: |
   Compare evolution of size as a function of luminosity and redshift and van der Wel et al (2014) HST-3D and CANDELS observations


### PR DESCRIPTION
This PR implements the validation criteria on the size-luminosity relations: a chisq/dof<1.2 between sims and validation data set for all tested redshift bins.  [A successful run of this test can be viewed here](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-06-01_17) (all v4 catalogs pass!). If you want to see the failure messages, you can examine [the runs on proto-dc2_v2.0](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-06-01_16).