### PR TITLE
Cosmetic and bug fixes for several tests; N(z) test using absolute ma…

### DIFF
--- a/descqa/DeltaSigmaTest.py
+++ b/descqa/DeltaSigmaTest.py
@@ -130,7 +130,7 @@ class DeltaSigmaTest(BaseValidationTest):
         ax = plt.subplot(111)
         plt.loglog(rp, gt, label='LOWZ-like sample from '+catalog_name)
         plt.errorbar(self.validation_data[:,0], self.validation_data[:,1], yerr=self.validation_data[:,2], label='SDSS LOWZ from Singh et al. (2015)')
-        plt.title('Number density {}/deg$^2$ vs 57/deg$^2$ for LOWZ'.format(nlens))
+        plt.title('Number density {:.1f}/deg$^2$ vs 57/deg$^2$ for LOWZ'.format(nlens))
         ax.set_xlabel('$r_p$ [Mpc/h]')
         ax.set_ylabel(r'$\Delta \Sigma [h \ M_\odot / pc^2]$')
         ax.legend()

--- a/descqa/EllipticityDistribution.py
+++ b/descqa/EllipticityDistribution.py
@@ -287,12 +287,13 @@ class EllipticityDistribution(BaseValidationTest):
                     sume2 += np.histogram(e_this, bins=self.ebins, weights=e_this**2)[0]
                     
                     #check borders
-                    if np.min(e_this)<0:
-                        any_low = True
-                        print('Value<0 found for morphology {} in catalog {}: {}'.format(morphology, catalog_name, np.min(e_this)))
-                    if np.max(e_this)>1:
-                        any_high = True
-                        print('Value>1 found for morphology {} in catalog {}: {}'.format(morphology, catalog_name, np.max(e_this)))
+                    if len(e_this)>0:
+                        if np.min(e_this)<0:
+                            any_low = True
+                            print('Value<0 found for morphology {} in catalog {}: {}'.format(morphology, catalog_name, np.min(e_this)))
+                        if np.max(e_this)>1:
+                            any_high = True
+                            print('Value>1 found for morphology {} in catalog {}: {}'.format(morphology, catalog_name, np.max(e_this)))
 
         #check that catalog has entries for quantity to be plotted
         if not np.asarray([N.sum() for N in N_array]).sum():

--- a/descqa/NumberDensityVersusRedshift.py
+++ b/descqa/NumberDensityVersusRedshift.py
@@ -58,6 +58,9 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         chi^2 value needs to be less than this value to pass the test
     use_diagonal_only : bool, optional (default: False)
         use only the diagonal terms of the convariance matric when calculating chi^2
+    rest_frame: boolean, optional (default: False)
+        use rest-frame magnitudes for cuts
+        Note that mag_lo and mag_hi need to be adjusted if rest_frame is set to `True`
     """
     #setup dict with parameters needed to read in validation data
     possible_observations = {
@@ -100,17 +103,24 @@ class NumberDensityVersusRedshift(BaseValidationTest):
     def __init__(self, z='redshift_true', band='i', N_zbins=10, zlo=0., zhi=1.1,
                  observation='', mag_lo=27, mag_hi=18, ncolumns=2, normed=True,
                  jackknife=False, N_jack=20, ra='ra', dec='dec', pass_limit=2., use_diagonal_only=False,
-                 **kwargs): #pylint: disable=W0231
+                 rest_frame=False, **kwargs): #pylint: disable=W0231
 
         #catalog quantities
         self.zlabel = z
-        possible_mag_fields = ('mag_{}_lsst',
-                               'mag_{}_sdss',
-                               'mag_{}_des',
-                               'mag_true_{}_lsst',
-                               'mag_true_{}_sdss',
-                               'mag_true_{}_des',
-                              )
+        self.rest_frame = rest_frame
+        if self.rest_frame:
+            possible_mag_fields = ('Mag_true_{}_lsst_z0',
+                                   'Mag_true_{}_sdss_z0',
+                                   'Mag_true_{}_des_z0',
+                                  )
+        else:
+            possible_mag_fields = ('mag_{}_lsst',
+                                   'mag_{}_sdss',
+                                   'mag_{}_des',
+                                   'mag_true_{}_lsst',
+                                   'mag_true_{}_sdss',
+                                   'mag_true_{}_des',
+                                  )
         self.possible_mag_fields = [f.format(band) for f in possible_mag_fields]
         self.band = band
 
@@ -210,7 +220,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                 return TestResult(skipped=True, summary='Missing required {} quantity'.format(jq))
 
         required_quantities = jackknife_quantities + [mag_field]
-        filtername = mag_field.rpartition('_')[-1].upper()
+        filtername = mag_field.split('_z0')[0].rpartition('_')[-1].upper()  #extract filtername
         filelabel = '_'.join((filtername, self.band))
 
         #setup plots

--- a/descqa/NumberDensityVersusRedshift.py
+++ b/descqa/NumberDensityVersusRedshift.py
@@ -102,8 +102,9 @@ class NumberDensityVersusRedshift(BaseValidationTest):
 
     def __init__(self, z='redshift_true', band='i', N_zbins=10, zlo=0., zhi=1.1,
                  observation='', mag_lo=27, mag_hi=18, ncolumns=2, normed=True,
-                 jackknife=False, N_jack=20, ra='ra', dec='dec', pass_limit=2., use_diagonal_only=False,
-                 rest_frame=False, **kwargs): #pylint: disable=W0231
+                 jackknife=False, N_jack=20, ra='ra', dec='dec', pass_limit=2., 
+                 use_diagonal_only=False, rest_frame=False, **kwargs):
+        # pylint: disable=W0231
 
         #catalog quantities
         self.zlabel = z
@@ -220,7 +221,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                 return TestResult(skipped=True, summary='Missing required {} quantity'.format(jq))
 
         required_quantities = jackknife_quantities + [mag_field]
-        filtername = mag_field.split('_z0')[0].rpartition('_')[-1].upper()  #extract filtername
+        filtername = mag_field.split('_')[(-1 if mag_field.startswith('m') else -2)].upper()  #extract filtername
         filelabel = '_'.join((filtername, self.band))
 
         #setup plots

--- a/descqa/SizeStellarMassLuminosity.py
+++ b/descqa/SizeStellarMassLuminosity.py
@@ -124,7 +124,7 @@ class SizeStellarMassLuminosity(BaseValidationTest):
 
                     ax.semilogy(validation_this[:,1], 10**validation_this[:,2], label=self.label_template.format(z_bin['z_min'], z_bin['z_max']))
                     ax.fill_between(validation_this[:,1], 10**validation_this[:,3], 10**validation_this[:,4], lw=0, alpha=0.2)
-                    ax.errorbar(default_L_bins, binned_size_kpc, binned_size_kpc_err, marker='o', ls='')
+                    ax.errorbar(default_L_bins, binned_size_kpc, binned_size_kpc_err, marker='o', ls='', label=catalog_name)
                     
                     validation = self.compute_chisq(default_L_bins, binned_size_kpc, binned_size_kpc_err,
                                                     validation_this[:,1], 10**validation_this[:,2])
@@ -151,8 +151,8 @@ class SizeStellarMassLuminosity(BaseValidationTest):
                     ax.semilogy(validation_this[:,1] + 0.2, validation_this[:,3], label='Disk', color=colors[1])
                     ax.fill_between(validation_this[:,1] + 0.2, validation_this[:,3] + validation_this[:,5], validation_this[:,3] - validation_this[:,5], lw=0, alpha=0.2, facecolor=colors[1])
 
-                    ax.errorbar(default_L_bins, binned_bulgesize_kpc, binned_bulgesize_kpc_err, marker='o', ls='', c=colors[0])
-                    ax.errorbar(default_L_bins+0.2, binned_disksize_kpc, binned_disksize_kpc_err, marker='o', ls='', c=colors[1])
+                    ax.errorbar(default_L_bins, binned_bulgesize_kpc, binned_bulgesize_kpc_err, marker='o', ls='', c=colors[0], label=catalog_name)
+                    ax.errorbar(default_L_bins+0.2, binned_disksize_kpc, binned_disksize_kpc_err, marker='o', ls='', c=colors[1], label=catalog_name)
                     ax.set_xlim([9, 13])
                     ax.set_ylim([1e-1, 25])
                     ax.set_yscale('log', nonposy='clip')
@@ -211,10 +211,14 @@ class SizeStellarMassLuminosity(BaseValidationTest):
             mask = validation_data!=0
             validation_points = validation_points[mask]
             validation_data = validation_data[mask]
-        if validation_points[-1]<validation_points[0]:
+        if len(validation_points)>0 and validation_points[-1]<validation_points[0]:
             validation_points = validation_points[::-1]
             validation_data = validation_data[::-1]
-        validation_at_binpoints = interpolate.CubicSpline(validation_points, validation_data)(bins)
+        if len(validation_points)>1:
+            validation_at_binpoints = interpolate.CubicSpline(validation_points, validation_data)(bins)
+        else:
+            validation_at_binpoints = binned_data #force chi-sq to zero if no validation data
+
         weights = 1./binned_err**2
         return np.sum(weights*(validation_at_binpoints-binned_data)**2)/len(weights)
                                   

--- a/descqa/configs/Nz_i_rest.yaml
+++ b/descqa/configs/Nz_i_rest.yaml
@@ -1,0 +1,9 @@
+subclass_name: NumberDensityVersusRedshift.NumberDensityVersusRedshift
+band: i
+mag_lo: -18
+mag_hi: -25
+zlo: 0.
+zhi: 3.0
+N_zbins: 30
+rest_frame: True
+description: 'Plot N(z) distributions for selected absolute magnitude cuts in specified band'


### PR DESCRIPTION
…gnitudes

This PR fixes some cosmetic issues in two tests (title for delta_sigma, legend in size test). It also fixes 2 bugs in the size and ellipticity distribution plots that cause the tests to crash when run on cosmoDC2. 
It also upgrades the N(z) test to run on rest-frame magnitudes, which is useful for debugging the baseline cosmoDC2 catalog. Sample outputs: [N(z)](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-13_1&test=Nz_i_rest), [Ellipticity](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-13_4&test=ellipticity_dist_COSMOS), [size](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-13_5&catalog=cosmoDC2_v0.4 )

> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 
