### PR TITLE
Change to CheckColors for rest-frame, readiness tests for cosmoDC2 an…

### DIFF
--- a/descqa/CheckColors.py
+++ b/descqa/CheckColors.py
@@ -21,6 +21,8 @@ class CheckColors(BaseValidationTest):
                                     'mag_true_{}_des',
                                     'Mag_true_{}_des_z01',
                                     'Mag_true_{}_sdss_z01',
+                                    'Mag_true_{}_lsst_z0',
+                                    'Mag_true_{}_sdss_z0',
                                     )
 
         if len(xcolor) != 2 or len(ycolor) != 2:

--- a/descqa/configs/readiness_baseDC2.yaml
+++ b/descqa/configs/readiness_baseDC2.yaml
@@ -1,0 +1,108 @@
+subclass_name: readiness_test.CheckQuantities
+description: 'Plot histograms of listed quantities and perform range, finiteness, mean and standard deviation checks.'
+included_by_default: true
+
+quantities_to_check:
+  - quantities: ['dec_true', 'dec']
+    label: 'deg'
+    min: [-36, -35]
+    max: [-25, -24]
+    median: [-32, -28]
+    mean: [-32, -28]
+    std: [1, 3]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: ['ra_true', 'ra']
+    label: 'deg'
+    min: [44, 46]
+    max: [56, 57]
+    median: [48, 52]
+    mean: [48, 52]
+    std: [1, 3]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: ['redshift_true', 'redshift']
+    label: redshift
+    min: [-0.05, 0.05]
+    max: [2.95, 3.05]
+    median: [1.8, 2.2]
+    mean: [1.8, 2.2]
+    std: [0.6, 0.7]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.001]
+
+  - quantities: 'shear_*'
+    min: [-0.2, 0]
+    max: [0, 0.2]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.01]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.04]
+
+  - quantities: 'position_angle*'
+    min: [0, 0.001]
+    max: [179.99, 180]
+    median: [89.9, 90.1]
+    mean: [89.9, 90.1]
+    std: [0, 90.0]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: 'convergence'
+    min: [-0.4, 0]
+    max: [0, 0.45]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.02]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'magnification'
+    min: [0.5, 1]
+    max: [1, 3]
+    median: [0.5, 1.5]
+    mean: [0.5, 1.5]
+    std: [0, 0.1]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'Mag_*lsst*'
+    label: Mag
+    min: [null, -23]
+    max: [-12, null]
+    mean: [-17, -8]
+    median: [-17, -8]
+    std: [0, 5]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'stellar_mass*'
+    log: true
+    min: [null, 10]
+    max: [10, 13]
+    median: [5.5, 7]
+    mean: [5.5, 7]
+    std: [0.5, 1.5]
+    f_nan: 0
+    f_outlier: [0, 0.025]
+
+relations_to_check:
+  - 'galaxy_id < 1e11'
+  - '1.0 / magnification ~== (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'
+
+uniqueness_to_check:
+  - quantity: galaxy_id
+  - quantity: halo_id
+    mask: is_central

--- a/descqa/configs/readiness_cosmoDC2.yaml
+++ b/descqa/configs/readiness_cosmoDC2.yaml
@@ -1,0 +1,262 @@
+subclass_name: readiness_test.CheckQuantities
+description: 'Plot histograms of listed quantities and perform range, finiteness, mean and standard deviation checks.'
+included_by_default: true
+
+quantities_to_check:
+  - quantities: ['dec_true', 'dec']
+    label: 'deg'
+    min: [-36, -35]
+    max: [-25, -24]
+    median: [-32, -28]
+    mean: [-32, -28]
+    std: [1, 3]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: ['ra_true', 'ra']
+    label: 'deg'
+    min: [44, 46]
+    max: [56, 57]
+    median: [48, 52]
+    mean: [48, 52]
+    std: [1, 3]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: ['redshift_true', 'redshift']
+    label: redshift
+    min: [-0.05, 0.05]
+    max: [2.95, 3.05]
+    median: [1.6, 2.0]
+    mean: [1.8, 2.2]
+    std: [0.6, 0.7]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.001]
+
+  - quantities: 'ellipticity_[12]*'
+    label: ellipticity
+    min: [-1, -0.8]
+    max: [0.8, 1]
+    median: [-0.05, 0.05]
+    mean: [-0.05, 0.05]
+    std: [0.1, 0.4]
+    f_nan: [0, 0.3]
+    f_inf: 0
+    f_outlier: [0, 0.06]
+
+  - quantities: ['ellipticity', 'ellipticity_[!12]*']
+    label: ellipticity_total
+    min: [0, 0.01]
+    max: [0.8, 1]
+    median: [0, 1]
+    mean: [0, 1]
+    std: [0.1, 0.4]
+    f_nan: [0, 0.3]
+    f_inf: 0
+    f_outlier: [0, 0.06]
+
+  - quantities: 'size*'
+    label: size
+    log: true
+    min: [-6, -1.5]
+    max: [0.5, 3]
+    median: [-2, 0]
+    mean: [-2, 0]
+    std: [0.1, 0.5]
+    f_nan: 0
+    f_zero: 0
+    f_inf: [0, 0.3]
+    f_outlier: [0, 0.01]
+    plot_min: -3
+    plot_max: 1
+
+  - quantities: size*_bulge*
+    f_nan: 0
+    f_inf: 0
+    min: [0, null]
+    plot_min: 0
+    plot_max: 3
+
+  - quantities: 'shear_*'
+    min: [-0.2, 0]
+    max: [0, 0.2]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.01]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.04]
+
+  - quantities: 'position_angle*'
+    min: [0, 0.001]
+    max: [179.99, 180]
+    median: [89.9, 90.1]
+    mean: [89.9, 90.1]
+    std: [0, 90.0]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: 'convergence'
+    min: [-0.4, 0]
+    max: [0, 0.45]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.02]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'magnification'
+    min: [0.5, 1]
+    max: [1, 3]
+    median: [0.5, 1.5]
+    mean: [0.5, 1.5]
+    std: [0, 0.1]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'sersic_disk'
+    min: 1
+    max: 1
+    median: 1
+    mean: 1
+    std: 0
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: 0
+
+  - quantities: 'sersic_bulge'
+    min: 4
+    max: 4
+    median: 4
+    mean: 4
+    std: 0
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: 0
+
+  - quantities: 'mag_*'
+    label: mag
+    min: [null, 15]
+    max: [25, null]
+    mean: [20, 32]
+    median: [20, 32]
+    std: [0, 5]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'Mag_*lsst*'
+    label: Mag
+    min: [null, -23]
+    max: [-12, null]
+    mean: [-17, -8]
+    median: [-17, -8]
+    std: [0, 5]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'stellar_mass*'
+    log: true
+    min: [null, 10]
+    max: [10, 13]
+    median: [6.5, 9]
+    mean: [6.5, 9]
+    std: [0.5, 1.5]
+    f_nan: 0
+    f_outlier: [0, 0.025]
+
+  - quantities: 'sed_*_*[0123456789]'
+    label: SED
+    log: true
+    min: [0.5, 7]
+    max: [9, 11]
+    mean: [3.5, 8]
+    median: [3.5, 8]
+    std: [0.5, 1.7]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.03]
+
+  - quantities: 'sed_*_*_disk'
+    label: Disk SED
+    log: true
+    min: [-23.0, -8.0]
+    max: [9, 10]
+    median: [3, 7]
+    mean: [3, 7]
+    std: [1, 2]
+    f_nan: 0
+    f_zero: 0
+    f_outlier: [0, 0.1]
+
+  - quantities: 'sed_*_*_bulge'
+    label: Bulge SED
+    log: true
+    min: [-12.0, -2.0]
+    max: [9, 11]
+    median: [2, 7]
+    mean: [2, 7]
+    std: [0.5, 1.5]
+    f_nan: 0
+    f_zero: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: A_v
+    min: [0.001, 3.1]
+    max: [0.001, 3.1]
+    median: [0.001, 3.1]
+    mean: [0.001, 3.1]
+    f_nan: 0
+    f_inf: 0
+    plot_min: -0.2
+    plot_max: 3
+
+  - quantities: R_v
+    min: [1, 5]
+    max: [1, 5]
+    median: [1, 5]
+    mean: [1, 5]
+    f_nan: 0
+    f_inf: 0
+    plot_min: -0.5
+
+  - quantities: bulge_to_total_ratio*
+    min: [0, 1]
+    max: [0, 1]
+    median: [0, 1]
+    mean: [0, 1]
+    f_nan: 0
+    f_inf: 0
+
+relations_to_check:
+  - 'galaxy_id < 1e11'
+  - 'size_minor_bulge_true <= size_bulge_true'
+  - 'size_minor_disk_true <= size_disk_true'
+  - 'size_minor_true <= size_true'
+  - '(size_bulge_true != 0) | (stellar_mass_bulge == 0)'
+  - 'stellar_mass_bulge <= stellar_mass'
+  - 'stellar_mass_disk <= stellar_mass'
+  - '1.0 / magnification ~== (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'
+  - 'size_minor_true / size_true ~== (1.0 - ellipticity_true) / (1.0 + ellipticity_true)'
+  - 'size_minor_disk_true / size_disk_true ~== (1.0 - ellipticity_disk_true) / (1.0 + ellipticity_disk_true)'
+  - 'size_minor_bulge_true ~== size_bulge_true * (1.0 - ellipticity_bulge_true) / (1.0 + ellipticity_bulge_true)'
+  - 'ellipticity_1_true ** 2.0 + ellipticity_2_true ** 2.0 ~== ellipticity_true ** 2.0'
+  - 'ellipticity_1_disk_true ** 2.0 + ellipticity_2_disk_true ** 2.0 ~== ellipticity_disk_true ** 2.0'
+  - 'ellipticity_1_bulge_true ** 2.0 + ellipticity_2_bulge_true ** 2.0 ~== ellipticity_bulge_true ** 2.0'
+
+uniqueness_to_check:
+  - quantity: galaxy_id
+  - quantity: halo_id
+    mask: is_central


### PR DESCRIPTION
…d baseDC2
Please see: [readiness test](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-16_3&test=readiness_baseDC2) and [ColorCheck](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-16&test=CheckColors)

> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 
