### PR TITLE
add verification test for galaxies in truth catalog

### DIFF
--- a/descqa/configs/truth_galaxy_verification_run1.1.yaml
+++ b/descqa/configs/truth_galaxy_verification_run1.1.yaml
@@ -1,0 +1,23 @@
+subclass_name: truth_galaxy_verification.TruthGalaxyVerification
+to_verify:
+  - truth: object_id
+    extragalactic: galaxy_id
+  - truth: redshift
+    extragalactic: redshift_true
+  - truth: mag_true_u
+    extragalactic: mag_true_u_lsst_no_host_extinction
+  - truth: mag_true_g
+    extragalactic: mag_true_g_lsst_no_host_extinction
+  - truth: mag_true_r
+    extragalactic: mag_true_r_lsst_no_host_extinction
+  - truth: mag_true_i
+    extragalactic: mag_true_i_lsst_no_host_extinction
+  - truth: mag_true_z
+    extragalactic: mag_true_z_lsst_no_host_extinction
+  - truth: mag_true_y
+    extragalactic: mag_true_y_lsst_no_host_extinction
+check_missing_galaxy_quantities:
+  - ra
+  - dec
+  - redshift
+  - mag_r_lsst

--- a/descqa/configs/truth_galaxy_verification_run1.1.yaml
+++ b/descqa/configs/truth_galaxy_verification_run1.1.yaml
@@ -1,4 +1,7 @@
 subclass_name: truth_galaxy_verification.TruthGalaxyVerification
+
+bins: 50
+
 to_verify:
   - truth: object_id
     extragalactic: galaxy_id
@@ -6,18 +9,35 @@ to_verify:
     extragalactic: redshift_true
   - truth: mag_true_u
     extragalactic: mag_true_u_lsst_no_host_extinction
+    always_show_plot: true
+    atol: 2.0
   - truth: mag_true_g
     extragalactic: mag_true_g_lsst_no_host_extinction
+    always_show_plot: true
+    atol: 1.5
   - truth: mag_true_r
     extragalactic: mag_true_r_lsst_no_host_extinction
+    always_show_plot: true
+    atol: 1.0
   - truth: mag_true_i
     extragalactic: mag_true_i_lsst_no_host_extinction
+    always_show_plot: true
+    atol: 1.0
   - truth: mag_true_z
     extragalactic: mag_true_z_lsst_no_host_extinction
+    always_show_plot: true
+    atol: 1.0
   - truth: mag_true_y
     extragalactic: mag_true_y_lsst_no_host_extinction
+    always_show_plot: true
+    atol: 1.0
+
 check_missing_galaxy_quantities:
   - ra
   - dec
   - redshift
   - mag_r_lsst
+
+description: |
+  Check if the galaxies in the truth catalog matches those in the extragalactic
+  catalog.

--- a/descqa/truth_galaxy_verification.py
+++ b/descqa/truth_galaxy_verification.py
@@ -47,7 +47,7 @@ class TruthGalaxyVerification(BaseValidationTest):
             if not catalog_instance.has_quantities(quantities):
                 failed.append(quantities)
                 continue
-                
+
             data = catalog_instance.get_quantities(quantities)
             q1 = data[quantities[0]]
             q2 = data[quantities[1]]
@@ -55,7 +55,7 @@ class TruthGalaxyVerification(BaseValidationTest):
 
             if masked is None and np.ma.is_masked(q2):
                 masked = q2.mask.copy()
-            
+
             if to_verify.get('atol') or to_verify.get('rtol'):
                 passed_this = np.allclose(q1, q2, **{k: float(to_verify.get(k, 0)) for k in ('atol', 'rtol')})
             else:
@@ -69,22 +69,22 @@ class TruthGalaxyVerification(BaseValidationTest):
                 if np.ma.is_masked(diff):
                     diff = diff.compressed()
                 self.plot_hist(diff, '{0[0]}:{0[1]} - {1[0]}:{1[1]}'.format(*quantities), 'diff_{:02d}'.format(i), output_dir, log=True)
-        
+
         if masked is not None and masked.any() and self.check_missing_galaxy_quantities:
             data = catalog_instance.get_quantities([('extragalactic', q) for q in self.check_missing_galaxy_quantities])
             for i, q in enumerate(self.check_missing_galaxy_quantities):
                 self.plot_hist(data[('extragalactic', q)][masked], q, 'missing_{:02d}'.format(i), output_dir, log=True)
-        
+
         if passed:
             with open(os.path.join(output_dir, 'results_passed.txt'), 'w') as f:
                 for q in passed:
                     f.write(str(q) + '\n')
-        
+
         if failed:
             with open(os.path.join(output_dir, 'results_failed.txt'), 'w') as f:
                 for q in failed:
                     f.write(str(q) + '\n')
-        
+
         return TestResult(score=len(failed), passed=(not failed))
 
     def plot_hist(self, data, xlabel, filename_prefix, output_dir, **kwargs):

--- a/descqa/truth_galaxy_verification.py
+++ b/descqa/truth_galaxy_verification.py
@@ -1,0 +1,98 @@
+from __future__ import unicode_literals, absolute_import, division
+import os
+import re
+import numpy as np
+from .base import BaseValidationTest, TestResult
+from .plotting import plt
+
+__all__ = ['TruthGalaxyVerification']
+
+class TruthGalaxyVerification(BaseValidationTest):
+    """
+    Verify the galaxy components of the truth catalog.
+    Works on a composite catalog that joins the truth and extragalactic catalogs.
+
+    Parameters
+    ----------
+    to_verify: list of dict
+        each dict should have keys `truth` and `extragalactic` that specify the column names
+        and also optional keys `atol` and `rtol` that specify tolerance
+    check_missing_galaxy_quantities : list of str
+        column names in extragalactic catalog to plot the properties of missing galaxies
+    """
+    def __init__(self, **kwargs):
+        to_verify = kwargs.get('to_verify')
+        if not to_verify:
+            raise ValueError('Nothing to verify!')
+        if not all(isinstance(d, dict) for d in to_verify):
+            raise ValueError('`to_verify` must be a list of dictionaries')
+        if not all('truth' in d and 'extragalactic' in d for d in to_verify):
+            raise ValueError('each dict in `to_verify` must have `truth` and `extragalactic`')
+        self.to_verify = tuple(to_verify)
+        self.check_missing_galaxy_quantities = tuple(kwargs.get('check_missing_galaxy_quantities', []))
+        self.bins = int(kwargs.get('bins', 100))
+
+    def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
+
+        passed = []
+        failed = []
+        masked = None
+
+        for i, to_verify in enumerate(self.to_verify):
+            quantities = [
+                ('extragalactic', to_verify['extragalactic']),
+                ('truth', to_verify['truth']),
+            ]
+            if not catalog_instance.has_quantities(quantities):
+                failed.append(quantities)
+                continue
+                
+            data = catalog_instance.get_quantities(quantities)
+            q1 = data[quantities[0]]
+            q2 = data[quantities[1]]
+            del data
+
+            if masked is None and np.ma.is_masked(q2):
+                masked = ~q2.mask
+            
+            if to_verify.get('atol') or to_verify.get('rtol'):
+                passed_this = np.allclose(q1, q2, **{k: float(to_verify.get(k, 0)) for k in ('atol', 'rtol')})
+            else:
+                passed_this = (q1 == q2).all()
+
+            if passed_this:
+                passed.append(quantities)
+            else:
+                failed.append(quantities)
+                diff = (q1 - q2)
+                if np.ma.is_masked(diff):
+                    diff = diff.compressed()
+                self.plot_hist(diff, '{0[0]}:{0[1]} - {1[0]}:{1[1]}'.format(*quantities), 'diff_{:02d}'.format(i), output_dir)
+        
+        if masked is not None and masked.any() and self.check_missing_galaxy_quantities:
+            data = catalog_instance.get_quantities([('extragalactic', q) for q in self.check_missing_galaxy_quantities])
+            for i, q in enumerate(self.check_missing_galaxy_quantities):
+                self.plot_hist(data[('extragalactic', q)][masked], q, 'missing_{:02d}'.format(i), output_dir)
+        
+        if passed:
+            with open(os.path.join(output_dir, 'results_passed.txt'), 'w') as f:
+                for q in passed:
+                    f.write(str(q) + '\n')
+        
+        if failed:
+            with open(os.path.join(output_dir, 'results_failed.txt'), 'w') as f:
+                for q in failed:
+                    f.write(str(q) + '\n')
+        
+        return TestResult(score=len(failed), passed=(not failed))
+
+    def plot_hist(self, data, xlabel, filename_prefix, output_dir, **kwargs):
+        filename = '{}_{}.png'.format(filename_prefix, re.sub('_+', '_', re.sub('\W+', '_', xlabel)).strip('_')).strip('_')
+        fig, ax = plt.subplots()
+        data = data[np.isfinite(data)]
+        if data.size:
+            ax.hist(data, self.bins, **kwargs)
+        ax.set_xlabel(xlabel)
+        fig.savefig(os.path.join(output_dir, filename))
+        plt.close(fig)
+

--- a/descqa/truth_galaxy_verification.py
+++ b/descqa/truth_galaxy_verification.py
@@ -54,7 +54,7 @@ class TruthGalaxyVerification(BaseValidationTest):
             del data
 
             if masked is None and np.ma.is_masked(q2):
-                masked = ~q2.mask
+                masked = q2.mask.copy()
             
             if to_verify.get('atol') or to_verify.get('rtol'):
                 passed_this = np.allclose(q1, q2, **{k: float(to_verify.get(k, 0)) for k in ('atol', 'rtol')})
@@ -68,12 +68,12 @@ class TruthGalaxyVerification(BaseValidationTest):
                 diff = (q1 - q2)
                 if np.ma.is_masked(diff):
                     diff = diff.compressed()
-                self.plot_hist(diff, '{0[0]}:{0[1]} - {1[0]}:{1[1]}'.format(*quantities), 'diff_{:02d}'.format(i), output_dir)
+                self.plot_hist(diff, '{0[0]}:{0[1]} - {1[0]}:{1[1]}'.format(*quantities), 'diff_{:02d}'.format(i), output_dir, log=True)
         
         if masked is not None and masked.any() and self.check_missing_galaxy_quantities:
             data = catalog_instance.get_quantities([('extragalactic', q) for q in self.check_missing_galaxy_quantities])
             for i, q in enumerate(self.check_missing_galaxy_quantities):
-                self.plot_hist(data[('extragalactic', q)][masked], q, 'missing_{:02d}'.format(i), output_dir)
+                self.plot_hist(data[('extragalactic', q)][masked], q, 'missing_{:02d}'.format(i), output_dir, log=True)
         
         if passed:
             with open(os.path.join(output_dir, 'results_passed.txt'), 'w') as f:

--- a/descqa/truth_galaxy_verification.py
+++ b/descqa/truth_galaxy_verification.py
@@ -31,6 +31,7 @@ class TruthGalaxyVerification(BaseValidationTest):
         self.to_verify = tuple(to_verify)
         self.check_missing_galaxy_quantities = tuple(kwargs.get('check_missing_galaxy_quantities', []))
         self.bins = int(kwargs.get('bins', 100))
+        super(TruthGalaxyVerification, self).__init__(**kwargs)
 
     def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
 
@@ -87,7 +88,7 @@ class TruthGalaxyVerification(BaseValidationTest):
         return TestResult(score=len(failed), passed=(not failed))
 
     def plot_hist(self, data, xlabel, filename_prefix, output_dir, **kwargs):
-        filename = '{}_{}.png'.format(filename_prefix, re.sub('_+', '_', re.sub('\W+', '_', xlabel)).strip('_')).strip('_')
+        filename = '{}_{}.png'.format(filename_prefix, re.sub('_+', '_', re.sub(r'\W+', '_', xlabel)).strip('_')).strip('_')
         fig, ax = plt.subplots()
         data = data[np.isfinite(data)]
         if data.size:

--- a/descqa/truth_galaxy_verification.py
+++ b/descqa/truth_galaxy_verification.py
@@ -101,5 +101,6 @@ class TruthGalaxyVerification(BaseValidationTest):
         ax.set_ylabel('Count')
         if title:
             ax.set_title(title)
+        fig.tight_layout()
         fig.savefig(os.path.join(output_dir, filename))
         plt.close(fig)


### PR DESCRIPTION
This PR adds a verification test for the galaxies in the truth catalog. You can take a look at [the DESCQA run](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-23_8&test=truth_galaxy_verification_run1.1&catalog=dc2_run1.1_extragalactic_truth_match) (As of 5:50p ET, the DESCQA web service is working fine. If you want to check out the plots, you can find them on NERSC at `/global/projecta/projectdirs/lsst/groups/CS/descqa/run/v2/2018-08/2018-08-23_8/truth_galaxy_verification_run1.1/dc2_run1.1_extragalactic_truth_match`.)

Note that, to try out this PR, you need to use this https://github.com/LSSTDESC/gcr-catalogs/pull/174

Here I attached one of the plots that shows the histogram of the difference in the r-band magnitude: 
![diff_04_extragalactic_mag_true_r_lsst_no_host_extinction_truth_mag_true_r](https://user-images.githubusercontent.com/3792659/44541180-2c86a080-a6d7-11e8-9a7b-616b00352084.png)

I am not sure if this is an OK result, I would have thought the agreement should be a lot better than this. Thoughts, @danielsf?  

Comments and suggestions to the test are welcome. 

This PR fixes #129 