### PR TITLE
Shear validation test: high-z bug fixes and mag cut implemented

### DIFF
--- a/descqa/configs/shear.yaml
+++ b/descqa/configs/shear.yaml
@@ -11,8 +11,10 @@ max_sep: 150
 sep_units: 'arcmin'
 bin_slop: 0.07
 zlo: 0.2
-zhi: 1.0
-ntomo: 3
+zhi: 3.0
+ntomo: 6
 z_range: 0.1
 do_jackknife: False
 N_clust: 5
+mag: 'restframe_extincted_sdss_abs_magr'
+maglim: -18.0

--- a/descqa/configs/shear.yaml
+++ b/descqa/configs/shear.yaml
@@ -10,11 +10,11 @@ min_sep: 1.0
 max_sep: 150
 sep_units: 'arcmin'
 bin_slop: 0.07
-zlo: 0.2
+zlo: 0.5
 zhi: 3.0
-ntomo: 6
-z_range: 0.1
+ntomo: 3
+z_range: 0.05
 do_jackknife: False
-N_clust: 5
+N_clust: 2
 mag: 'Mag_true_r_sdss_z0' 
 maglim: -19.0

--- a/descqa/configs/shear.yaml
+++ b/descqa/configs/shear.yaml
@@ -10,11 +10,11 @@ min_sep: 1.0
 max_sep: 150
 sep_units: 'arcmin'
 bin_slop: 0.07
-zlo: 0.2
+zlo: 0.1
 zhi: 3.0
-ntomo: 6
-z_range: 0.1
+ntomo: 3
+z_range: 0.05
 do_jackknife: False
 N_clust: 5
-mag: 'restframe_extincted_sdss_abs_magr'
-maglim: -18.0
+mag: 'Mag_true_r_sdss_z0'
+maglim: -19.0

--- a/descqa/configs/shear.yaml
+++ b/descqa/configs/shear.yaml
@@ -10,11 +10,11 @@ min_sep: 1.0
 max_sep: 150
 sep_units: 'arcmin'
 bin_slop: 0.07
-zlo: 0.1
+zlo: 0.2
 zhi: 3.0
-ntomo: 3
-z_range: 0.05
+ntomo: 6
+z_range: 0.1
 do_jackknife: False
 N_clust: 5
-mag: 'Mag_true_r_sdss_z0'
+mag: 'Mag_true_r_sdss_z0' 
 maglim: -19.0

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -9,10 +9,10 @@ from sklearn.cluster import k_means
 import treecorr
 import camb
 import camb.correlations
-import astropy.units as u # pylint: disable=no-member
-import astropy.constants as const # pylint: disable=no-member
-from GCR import GCRQuery
+import astropy.units as u
+import astropy.constants as const
 from astropy.cosmology import WMAP7 # pylint: disable=no-name-in-module
+from GCR import GCRQuery
 from .base import BaseValidationTest, TestResult
 from .plotting import plt
 pars = camb.CAMBparams()
@@ -90,7 +90,7 @@ class ShearTest(BaseValidationTest):
         ''' This is the inner bit of GWL lensing kernel - z is related to x, not chi'''
         z = chi_int(x)
         H_z = cosmo.H(z).to(1./u.s).value
-        dchidz = const.c.to(u.Mpc/u.s).value/H_z
+        dchidz = const.c.to(u.Mpc/u.s).value/H_z  # pylint: disable=no-member
         return n(z) / dchidz * (x - chi) / x
 
     def galaxy_W(self, z, n, chi_int, cosmo, chi_max):

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -270,7 +270,7 @@ class ShearTest(BaseValidationTest):
         print(cosmo)
 
         pars.set_cosmology(H0=cosmo.H0.value, ombh2=cosmo.Ob0*cosmo.h**2, omch2=(cosmo.Om0-cosmo.Ob0)*cosmo.h**2)
-        pars.InitPower.set_params(ns=ns, As = 2.168e-9*(s8/0.8)**2)
+        pars.InitPower.set_params(ns=ns, As=2.168e-9*(s8/0.8)**2)
         camb.set_halofit_version(version='takahashi')
         p = camb.get_matter_power_interpolator(pars, nonlinear=True, k_hunit=False, hubble_units=False, kmax=100., zmax=self.zhi+1., k_per_logint=False).P
         z_max = np.max(catalog_data[self.z])

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -10,7 +10,7 @@ import treecorr
 import camb
 import camb.correlations
 import astropy.units as u # pylint: disable=no-member
-import astropy.constants as const
+import astropy.constants as const # pylint: disable=no-member
 from GCR import GCRQuery
 from astropy.cosmology import WMAP7 # pylint: disable=no-name-in-module
 from .base import BaseValidationTest, TestResult

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -85,7 +85,8 @@ class ShearTest(BaseValidationTest):
         n2 = interp1d(z, n / n2_sum, bounds_error=False, fill_value=0.0, kind='cubic')
         return n2
 
-    def integrand_w(self, x, n, chi, chi_int, cosmo):
+    @staticmethod
+    def integrand_w(x, n, chi, chi_int, cosmo):
         ''' This is the inner bit of GWL lensing kernel - z is related to x, not chi'''
         z = chi_int(x)
         H_z = cosmo.H(z).to(1./u.s).value

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -9,7 +9,7 @@ from sklearn.cluster import k_means
 import treecorr
 import camb
 import camb.correlations
-import astropy.units as u
+import astropy.units as u # pylint: disable=no-member
 import astropy.constants as const
 from GCR import GCRQuery
 from astropy.cosmology import WMAP7 # pylint: disable=no-name-in-module

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -258,7 +258,6 @@ class ShearTest(BaseValidationTest):
         '''
         run test on a single catalog
         '''
-        f1 = open('./logfile','w+')
         # check if needed quantities exist
         if not catalog_instance.has_quantities([self.z, self.ra, self.dec]):
             return TestResult(skipped=True, summary='do not have needed location quantities')
@@ -280,7 +279,6 @@ class ShearTest(BaseValidationTest):
         pars.set_cosmology(H0=cosmo.H0.value, ombh2=cosmo.Ob0*(cosmo.H0.value /100.)**2, omch2=(cosmo.Om0-cosmo.Ob0)*(cosmo.H0.value /100.)**2)
         #TODO: set sigma8 value to catalog value when this becomes possible
 
-        f1.write("set cosmology\n")
         pars.InitPower.set_params(ns=0.963, As=2.168e-9)
         #pars.InitPower.set_params(ns=0.963,As = 2.168e-9*(sigma8/0.8 )**2)
         camb.set_halofit_version(version='takahashi')
@@ -305,7 +303,6 @@ class ShearTest(BaseValidationTest):
         fig, ax = plt.subplots(nrows=2, ncols=ntomo, sharex=True, squeeze=False, figsize=(ntomo*5, 5))
         zmeans = np.linspace(self.zlo, self.zhi, ntomo+2)[1:-1]
         for ii in range(ntomo):
-            f1.write(str(ii) +"\n")
             z_mean = zmeans[ii]
             zlo2 = z_mean - self.z_range
             zhi2 = z_mean + self.z_range
@@ -328,15 +325,11 @@ class ShearTest(BaseValidationTest):
                 verbose=True)
             gg.process(cat_s)
             #NOTE commented out for now - will need to change back
-            #r = np.exp(gg.meanlogr)
             r = np.exp(gg.meanlogr)
             #NOTE: We are computing 10^6 x correlation function for easier comparison
             xip = gg.xip * 1.e6
             xim = gg.xim * 1.e6
-            #xip = np.zeros((self.nbins))
-            #xim = np.zeros((self.nbins))
  
-            f1.write("npairs computed \n")
             print("npairs  = ")
             print(gg.npairs)
 	    #sig = np.sqrt(gg.varxi)  # this is shape noise only - should be very low for simulation data
@@ -361,7 +354,6 @@ class ShearTest(BaseValidationTest):
 
             n_z = catalog_data[self.z][zmask*mask_mag]
             xvals, theory_plus, theory_minus = self.theory_corr(n_z, r, 15000, cosmo, p, chi_recomb)
-            f1.write("done theory \n")
             theory_plus = theory_plus * 1.e6
             theory_minus = theory_minus * 1.e6
 
@@ -374,7 +366,6 @@ class ShearTest(BaseValidationTest):
             print(theory_minus)
             print(xip)
             print(xim)
-            f1.write("all done! \n")
 
 	    #The following are further treecorr correlation functions that could be added in later to extend the test
 	    #treecorr.NNCorrelation(nbins=20, min_sep=2.5, max_sep=250, sep_units='arcmin')

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -48,7 +48,7 @@ class ShearTest(BaseValidationTest):
                  **kwargs):
         #pylint: disable=W0231
 
-        plt.rcParams.update({'font.size': 9})
+        plt.rcParams['font.size'] = 9
 
         self.z = z
         #sep-bounds and binning
@@ -107,7 +107,6 @@ class ShearTest(BaseValidationTest):
 
     def integrand_lensing_limber(self, chi, l, galaxy_W_int, chi_int, p):
         '''return overall integrand for one value of l'''
-        #chi_unit = chi * u.Mpc
         z = chi_int(chi)
         k = (l + 0.5) / chi
         integrand = p(z, k, grid=False) * galaxy_W_int(z)**2 / chi**2
@@ -178,11 +177,12 @@ class ShearTest(BaseValidationTest):
             verbose=True)
         for i in range(N_clust):
             ##### shear computation excluding each jack-knife region
+            mask_jack = (labs != i)
             cat_s = treecorr.Catalog(
-                ra=catalog_data[self.ra][labs != i],
-                dec=catalog_data[self.dec][labs != i],
-                g1=catalog_data[self.e1][labs != i] - np.mean(catalog_data[self.e1][labs != i]),
-                g2=-(catalog_data[self.e2][labs != i] - np.mean(catalog_data[self.e2][labs != i])),
+                ra=catalog_data[self.ra][mask_jack],
+                dec=catalog_data[self.dec][mask_jack],
+                g1=catalog_data[self.e1][mask_jack] - np.mean(catalog_data[self.e1][mask_jack]),
+                g2=-(catalog_data[self.e2][mask_jack] - np.mean(catalog_data[self.e2][mask_jack])),
                 ra_units='deg',
                 dec_units='deg')
             gg.process(cat_s)
@@ -302,7 +302,7 @@ class ShearTest(BaseValidationTest):
             zlo2 = z_mean - self.z_range
             zhi2 = z_mean + self.z_range
             print(zlo2, zhi2)
-            zmask = (catalog_data[self.z] < zhi2)*(catalog_data[self.z] > zlo2)
+            zmask = (catalog_data[self.z] < zhi2) & (catalog_data[self.z] > zlo2)
             mask = zmask & mask_mag
             # compute shear auto-correlation
             cat_s = treecorr.Catalog(

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -271,7 +271,7 @@ class ShearTest(BaseValidationTest):
 
         pars.set_cosmology(H0=cosmo.H0.value, ombh2=cosmo.Ob0*cosmo.h**2, omch2=(cosmo.Om0-cosmo.Ob0)*cosmo.h**2)
         pars.InitPower.set_params(ns=ns, As=2.168e-9*(s8/0.8)**2)
-        camb.set_halofit_version(version='takahashi')
+        camb.set_halofit_version(version='takahashi') # pylint: disable=no-member
         p = camb.get_matter_power_interpolator(pars, nonlinear=True, k_hunit=False, hubble_units=False, kmax=100., zmax=self.zhi+1., k_per_logint=False).P
         z_max = np.max(catalog_data[self.z])
         if self.zhi>z_max:

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -106,7 +106,8 @@ class ShearTest(BaseValidationTest):
         W = np.array(val_array) * prefactor * (u.Mpc)  # now unitless
         return W
 
-    def integrand_lensing_limber(self, chi, l, galaxy_W_int, chi_int, p):
+    @staticmethod
+    def integrand_lensing_limber(chi, l, galaxy_W_int, chi_int, p):
         '''return overall integrand for one value of l'''
         z = chi_int(chi)
         k = (l + 0.5) / chi

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -100,7 +100,7 @@ class ShearTest(BaseValidationTest):
             0)
         prefactor = cst * chi * (1. + z) * u.Mpc
         val_array = []
-        for i in range(len(z)):
+        for chi_this in chi:
             val_array.append(quad(self.integrand_w, chi_this, chi_max, args=(n, chi_this, chi_int, cosmo))[0])
         W = np.array(val_array) * prefactor * (u.Mpc)  # now unitless
         return W

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -101,7 +101,7 @@ class ShearTest(BaseValidationTest):
         prefactor = cst * chi * (1. + z) * u.Mpc
         val_array = []
         for i in range(len(z)):
-            val_array.append(quad(self.integrand_w, chi[i], chi_max, args=(n, chi[i], chi_int, cosmo))[0])
+            val_array.append(quad(self.integrand_w, chi_this, chi_max, args=(n, chi_this, chi_int, cosmo))[0])
         W = np.array(val_array) * prefactor * (u.Mpc)  # now unitless
         return W
 

--- a/descqa/shear_test.py
+++ b/descqa/shear_test.py
@@ -12,7 +12,7 @@ import camb.correlations
 import astropy.units as u
 import astropy.constants as const
 from GCR import GCRQuery
-from astropy.cosmology import WMAP7
+from astropy.cosmology import WMAP7 # pylint: disable=no-name-in-module
 from .base import BaseValidationTest, TestResult
 from .plotting import plt
 pars = camb.CAMBparams()


### PR DESCRIPTION
The updates for the test are as follows:

- catch for missing cosmology 
- bug fix for high redshift theory
- magnitude cut to speed up test 

There was a bug stopping the theory correlations being computed above redshift 2, I've also added a magnitude cut for a magnitude quantity and limit defined in the yaml file (note that current default is for umachine set-up) to let the test run in a more reasonable time-frame. 

The portal link should be: https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-24_15
