### PR TITLE
update image psd test to show per-sensor result

### DIFF
--- a/descqa/ImgPkTest.py
+++ b/descqa/ImgPkTest.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, absolute_import, division
 import os
+from itertools import product
 import numpy as np
 from scipy.stats import binned_statistic, chi2
 from astropy.table import Table
@@ -41,56 +42,31 @@ class ImgPkTest(BaseValidationTest):
         self.validation_data_label = validation_data_label
         self.pixel_scale = pixel_scale
 
-    def get_rebinning(self, raft):
-        if self.rebinning is None:
-            return first(raft.sensors.values()).default_rebinning
-        return self.rebinning
-
-    def calc_psd(self, raft, bins=200):
-        rebinning = self.get_rebinning(raft)
-
-        # Assemble the 3 x 3 raft's image
-        # TODO: Need to use LSST's software to handle the gaps properly
-        total_data = np.array([raft.sensors['S%d%d'%(i,j)].get_data(rebinning=rebinning) for i in range(3) for j in range(3)])
-        xdim, ydim = total_data.shape[1:]
-        total_data = total_data.reshape(3, 3, xdim, ydim).swapaxes(1, 2).reshape(3*xdim, 3*ydim)
-
-        # FFT of the density contrast
-        FT = np.fft.fft2(total_data / total_data.mean() - 1)
+    def calc_psd(self, image_data, rebinning=1, bins=200):
+        FT = np.fft.fft2(image_data / image_data.mean() - 1)
         n_kx, n_ky = FT.shape
         psd = np.square(np.abs(FT)).ravel()
         spacing = self.pixel_scale * rebinning
         k_rad = np.hypot(*np.meshgrid(np.fft.fftfreq(n_kx, spacing), np.fft.fftfreq(n_ky, spacing), indexing='ij')).ravel()
-
         k_rad /= (2.0 * np.pi)
         psd *= (spacing / n_kx) * (spacing / n_ky)
-
         return binned_statistic(k_rad, [k_rad, psd], bins=bins)[0]
 
-    def plot_hist(self, ax, raft):
-        rebinning = self.get_rebinning(raft)
-        for key, image in raft.sensors.items():
-            ax.hist(image.get_data(rebinning=rebinning).ravel(),
-                    histtype='step', range=(200, 2000), bins=200, label=key, log=True)
-        ax.set_xlabel('Background level [ADU]')
-        ax.set_ylabel('Number of pixels')
-        ax.legend(loc='best', ncol=2)
-        return ax
-
-    def plot_psd(self, ax, k, psd, label):
-        ax.loglog(k, psd, label=label)
-        if self.validation_data is not None:
-            ax.loglog(self.validation_data['k'], self.validation_data['Pk'], label=self.validation_data_label)
-        ax.set_xlabel('k [arcmin$^{-1}$]')
-        ax.set_ylabel('P(k)')
-        ax.set_xlim(0.005, 2)
-        ax.set_ylim(1.0e-4, 2)
-        ax.legend(loc='best')
-        return ax
-
     def run_on_single_catalog(self, catalog_instance, catalog_name, output_dir):
-        # The catalog instance is a focal plane
-        rafts = catalog_instance.focal_plane.rafts
+
+        if hasattr(catalog_instance, 'focal_plane'):
+            focal_plane = catalog_instance.focal_plane
+        elif hasattr(catalog_instance, 'focal_planes'):
+            focal_plane = first(catalog_instance.focal_planes.values())
+        else:
+            return TestResult(skipped=True, summary='Not an e-image!')
+
+        rafts = focal_plane.rafts
+
+        if self.rebinning is None:
+            rebinning = catalog_instance.default_rebinning
+        else:
+            rebinning = self.rebinning
 
         if self.raft is None:
             raft_names = list(rafts)
@@ -102,30 +78,60 @@ class ImgPkTest(BaseValidationTest):
         if not all(raft_name in rafts for raft_name in raft_names):
             return TestResult(skipped=True, summary='Not all rafts exist!')
 
+        sensor_names = ['S%d%d'%(i,j) for i in range(3) for j in range(3)]
+
         total_chi2 = 0
-        count = 0
+        total_dof = 0
+
         for raft_name in raft_names:
             raft = rafts[raft_name]
-            fig, ax = plt.subplots(2, 1, figsize=(7, 7))
-            self.plot_hist(ax[0], raft)
-            if len(raft.sensors) == 9:
-                k, psd = self.calc_psd(raft)
-                self.plot_psd(ax[1], k, psd, label=raft_name)
-                if self.validation_data is not None:
-                    psd_log_interp = np.interp(self.validation_data['k'], k, np.log(psd), left=-np.inf, right=-np.inf)
-                    count += 1
-                    total_chi2 += np.square((psd_log_interp - np.log(self.validation_data['Pk']))).sum()
+            data = [raft.sensors[name].get_data(rebinning) if name in raft.sensors else None for name in sensor_names]
+
+            fig, ax = plt.subplots(2, 1, figsize=(7, 8))
+            for sensor, data_this in zip(sensor_names, data):
+                if data_this is None:
+                    continue
+
+                ax[0].hist(data_this.ravel(), np.linspace(200, 2000, 181),
+                           histtype='step', log=True, label=sensor)
+                ax[1].loglog(*self.calc_psd(data_this, rebinning), label=sensor, alpha=0.8)
+
+            if sum((1 for data_this in data if data_this is not None)) == 9:
+                data = np.array(data)
+                xdim, ydim = data.shape[1:]
+                data = data.reshape(3, 3, xdim, ydim).swapaxes(1, 2).reshape(3*xdim, 3*ydim)
+                k, psd = self.calc_psd(data, rebinning)
+                ax[1].loglog(k, psd, label='all', c='k')
             else:
-                msg = 'Raft {} is not complete!'.format(raft_name)
-                ax[1].text(0.05, 0.5, msg, transform=ax[1].transAxes)
-                print('[WARNING]', msg)
+                psd = None
+
+            if self.validation_data is not None:
+                ax[1].loglog(self.validation_data['k'], self.validation_data['Pk'], label=self.validation_data_label, c='r', ls=':')
+
+            if self.validation_data is not None and psd is not None:
+                psd_log_interp = np.interp(self.validation_data['k'], k, np.log(psd), left=np.nan, right=np.nan)
+                mask = np.isfinite(psd_log_interp)
+                total_dof += np.count_nonzero(mask)
+                total_chi2 += np.square((psd_log_interp[mask] - np.log(self.validation_data['Pk'][mask]))).sum()
+
+            ax[0].legend(ncol=3)
+            ax[1].legend(ncol=3)
+
+            ax[0].set_title('{} - {}'.format(raft_name, catalog_name))
+            ax[0].set_xlabel('Background level [ADU]')
+            ax[0].set_ylabel('Number of pixels')
+            ax[0].set_ylim(None, 1e5)
+            ax[1].set_xlabel('k [arcmin$^{-1}$]')
+            ax[1].set_ylabel('P(k)')
+            ax[1].set_xlim(0.005, 2)
+            ax[1].set_ylim(1.0e-4, 2)
+
             fig.tight_layout()
             fig.savefig(os.path.join(output_dir, 'plot_{}.png'.format(raft_name)))
             plt.close(fig)
-        if count:
-            total_chi2 /= count
-        ndof = len(self.validation_data['k']) - 1
-        score = chi2.cdf(total_chi2, ndof)
+
+        score = chi2.cdf(total_chi2, total_dof)
+
         # Check criteria to pass or fail (images in the edges of the focal plane
         # will have way more power than the ones in the center if they are not
         # flattened, we require the power to be within 2-sigma ( p < 0.95)

--- a/descqa/ImgPkTest.py
+++ b/descqa/ImgPkTest.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, absolute_import, division
 import os
-from itertools import product
 import numpy as np
 from scipy.stats import binned_statistic, chi2
 from astropy.table import Table


### PR DESCRIPTION
This PR improves the image power spectra test to show per-sensor spectra. 

[A DESCQA run can be found here](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-08-30_46&test=image_power_spec), which shows the test results for e-images of both Run 1.2p and the newly arrived Run 1.2i!

You may still encounter timeout error when visiting the DESCQA web app. You can find the plots on NERSC at `/global/projecta/projectdirs/lsst/groups/CS/descqa/run/v2/2018-08/2018-08-30_46/image_power_spec`. Here I post one of them (raft 24, visit 181898) for both runs (upper two: 1.2p; lower two: 1.2i):

![run1 2p_r24](https://user-images.githubusercontent.com/3792659/44889223-f92dae00-aca2-11e8-9d52-918cebe12890.png)
![run1 2i_r24](https://user-images.githubusercontent.com/3792659/44889226-fb900800-aca2-11e8-8336-95f29e8f22a7.png)

(Note: to run this PR, you'll need the latest gcr-catalogs that contains the updated e-image reader)