### PR TITLE
upgrade readiness test to display an aggregated report

### DIFF
--- a/descqa/configs/readiness_instance_agn.yaml
+++ b/descqa/configs/readiness_instance_agn.yaml
@@ -9,7 +9,7 @@ always_show_plot: false
 quantities_to_check:
   - quantities: 'agn_gal/mag_norm'
     label: 'mag'
-    min: 10, 30
+    min: [10, null]
     f_inf: 0
     f_nan: 0
-    f_outlier: 0, 0.005
+    f_outlier: [0, 0.01]

--- a/descqa/configs/readiness_instance_agn.yaml
+++ b/descqa/configs/readiness_instance_agn.yaml
@@ -1,0 +1,11 @@
+subclass_name: readiness_test.CheckQuantities
+description: 'Check AGN magnitudes in the instance catalogs'
+included_by_default: true
+
+enable_individual_summary: false
+enable_aggregated_summary: true
+always_show_plot: false
+
+quantities_to_check:
+  - quantities: 'agn_gal/mag_norm'
+    label: 'mag'

--- a/descqa/configs/readiness_instance_star.yaml
+++ b/descqa/configs/readiness_instance_star.yaml
@@ -7,7 +7,7 @@ enable_aggregated_summary: true
 always_show_plot: false
 
 quantities_to_check:
-  - quantities: 'star/mag_norm', 'bright_stars/mag_norm'
+  - quantities: 'star/mag_norm'
     label: 'mag'
     min: 10, 30
     f_inf: 0

--- a/descqa/configs/readiness_instance_star.yaml
+++ b/descqa/configs/readiness_instance_star.yaml
@@ -7,7 +7,7 @@ enable_aggregated_summary: true
 always_show_plot: false
 
 quantities_to_check:
-  - quantities: 'agn_gal/mag_norm'
+  - quantities: 'star/mag_norm', 'bright_stars/mag_norm'
     label: 'mag'
     min: 10, 30
     f_inf: 0

--- a/descqa/configs/readiness_instance_star.yaml
+++ b/descqa/configs/readiness_instance_star.yaml
@@ -9,7 +9,7 @@ always_show_plot: false
 quantities_to_check:
   - quantities: 'star/mag_norm'
     label: 'mag'
-    min: 10, 30
+    min: [10, null]
     f_inf: 0
     f_nan: 0
-    f_outlier: 0, 0.005
+    f_outlier: [0, 0.01]

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -129,7 +129,7 @@ class CheckQuantities(BaseValidationTest):
         self.always_show_plot = bool(kwargs.get('always_show_plot', True))
 
         self.nbins = int(kwargs.get('nbins', 50))
-        self.prop_cycle = cycle(iter(plt.rcParams['axes.prop_cycle']))
+        self.prop_cycle = None
 
         self.current_catalog_name = None
         self.current_failed_count = None
@@ -140,7 +140,7 @@ class CheckQuantities(BaseValidationTest):
 
         super(CheckQuantities, self).__init__(**kwargs)
 
-    def record_result(self, results, quantity_name=None, more_info=None, failed=None):
+    def record_result(self, results, quantity_name=None, more_info=None, failed=None, individual_only=False):
         if isinstance(results, dict):
             self.current_failed_count += sum(1 for v in results.values() if v[1] == 'fail')
         elif failed:
@@ -152,7 +152,7 @@ class CheckQuantities(BaseValidationTest):
             else:
                 self._individual_table.append(self.format_result_row(results, quantity_name, more_info))
 
-        if self.enable_aggregated_summary:
+        if self.enable_aggregated_summary and not individual_only:
             if quantity_name is None:
                 results = '{} {}'.format(self.current_catalog_name, results) if self.current_catalog_name else results
                 self._aggregated_header.append(self.format_result_header(results, failed))
@@ -211,6 +211,7 @@ class CheckQuantities(BaseValidationTest):
 
         all_quantities = sorted(map(str, catalog_instance.list_all_quantities(True)))
 
+        self.prop_cycle = cycle(iter(plt.rcParams['axes.prop_cycle']))
         self.current_catalog_name = catalog_name
         self.current_failed_count = 0
         galaxy_count = None
@@ -218,7 +219,8 @@ class CheckQuantities(BaseValidationTest):
 
         self.record_result('Running readiness test on {} {}'.format(
             catalog_name,
-            getattr(catalog_instance, 'version', '')
+            getattr(catalog_instance, 'version', ''),
+            individual_only=True,
         ))
 
         for i, checks in enumerate(self.quantities_to_check):

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -274,12 +274,13 @@ class CheckQuantities(BaseValidationTest):
                     if s in checks:
                         try:
                             min_value, max_value = checks[s]
+                        except (TypeError, ValueError):
+                            flag |= (s_value != checks[s])
+                        else:
                             if min_value is not None:
                                 flag |= (s_value < min_value)
                             if max_value is not None:
                                 flag |= (s_value > max_value)
-                        except TypeError:
-                            flag |= (s_value != checks[s])
                     else:
                         flag = None
                     result_this_quantity[s] = (

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -172,7 +172,7 @@ class CheckQuantities(BaseValidationTest):
     def format_result_header(results, failed=False):
         return '<span {1}>{0}</span>'.format(results, 'class="fail"' if failed else '')
 
-    def generate_summery(self, output_dir, aggregated=False):
+    def generate_summary(self, output_dir, aggregated=False):
         if aggregated:
             if not self.enable_aggregated_summary:
                 return
@@ -354,9 +354,9 @@ class CheckQuantities(BaseValidationTest):
             else:
                 self.record_result('{} has repeated entries!'.format(label), failed=True)
 
-        self.generate_summery(output_dir)
+        self.generate_summary(output_dir)
 
         return TestResult(passed=(self.current_failed_count == 0), score=self.current_failed_count)
 
     def conclude_test(self, output_dir):
-        self.generate_summery(output_dir, aggregated=True)
+        self.generate_summary(output_dir, aggregated=True)


### PR DESCRIPTION
This PR upgrades the readiness test so that it can display an aggregated summary report when the test is run on multiple catalogs *and* the option `enable_aggregated_summary` is turned on. 

This PR also adds two new test configs that use this new feature to validate the instance catalogs as requested in #152. 

[Here's a test run](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-09-02_6), and you can see aggregated summary report [for AGN mags here](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-09-02_6&test=readiness_instance_agn&right=2018-09/2018-09-02_6/readiness_instance_agn/SUMMARY.html) and [for star mags here](https://portal.nersc.gov/project/lsst/descqa/v2/?run=2018-09-02_6&test=readiness_instance_star&right=2018-09/2018-09-02_6/readiness_instance_agn/SUMMARY.html). 

The above test run only ran on a small number of instance catalogs. I'll run the test over all ~ 2,000 instance catalogs, but that'll take some more time (and I probably should submit a batch job for that). I create this PR first to see if people have comments. 

This PR fixes #152.