### PR TITLE
update the front page of website

### DIFF
--- a/descqaweb/config.py
+++ b/descqaweb/config.py
@@ -21,3 +21,5 @@ See <a href="https://arxiv.org/abs/1709.09665" target="_blank">the DESCQA paper<
 Full details about the catalogs and tests, and how to contribute, are available <a href="https://confluence.slac.stanford.edu/x/Z0uKDQ" target="_blank">here</a> (collaborators only).
 The source code of DESCQA is hosted in <a href="https://github.com/LSSTDESC/descqa/" target="_blank">this GitHub repo</a>.
 '''
+
+use_latest_run_as_home = False

--- a/descqaweb/main.py
+++ b/descqaweb/main.py
@@ -61,7 +61,7 @@ def run():
 
     print(env.get_template('header.html').render(full_header=True, please_wait=True, config=config))
     sys.stdout.flush()
-    if config.use_latest_run_as_home:
+    if getattr(config, 'use_latest_run_as_home', True):
         print(env.get_template('matrix.html').render(**prepare_matrix(
             run=_run,
             catalog_prefix=form.getfirst('catalog_prefix'),

--- a/descqaweb/main.py
+++ b/descqaweb/main.py
@@ -61,7 +61,7 @@ def run():
 
     print(env.get_template('header.html').render(full_header=True, please_wait=True, config=config))
     sys.stdout.flush()
-    if getattr(config, 'use_latest_run_as_home', True):
+    if _run or getattr(config, 'use_latest_run_as_home', True):
         print(env.get_template('matrix.html').render(**prepare_matrix(
             run=_run,
             catalog_prefix=form.getfirst('catalog_prefix'),

--- a/descqaweb/main.py
+++ b/descqaweb/main.py
@@ -61,8 +61,11 @@ def run():
 
     print(env.get_template('header.html').render(full_header=True, please_wait=True, config=config))
     sys.stdout.flush()
-    print(env.get_template('matrix.html').render(**prepare_matrix(
-        run=_run,
-        catalog_prefix=form.getfirst('catalog_prefix'),
-        test_prefix=form.getfirst('test_prefix'),
-    )))
+    if config.use_latest_run_as_home:
+        print(env.get_template('matrix.html').render(**prepare_matrix(
+            run=_run,
+            catalog_prefix=form.getfirst('catalog_prefix'),
+            test_prefix=form.getfirst('test_prefix'),
+        )))
+    else:
+        print(env.get_template('home.html').render(general_info=config.general_info))

--- a/descqaweb/templates/home.html
+++ b/descqaweb/templates/home.html
@@ -18,8 +18,8 @@ Here are a few examples:<br>
 
 When navigating the DESCQA tests, you may find the following links useful:<br>
 <ul>
-  <li><a class="everblue" href="https://github.com/LSSTDESC/gcr-catalogs#available-catalogs">List of available catalogs</a> (that can be accessed by DESCQA), including a brief description of each catalog.</li>
-  <li><a class="everblue" href="https://github.com/LSSTDESC/descqa/tree/master/descqa/configs">List of available DESCQA tests</a> (each yaml file has a "description" field).</li>
+  <li><a class="everblue" href="https://github.com/LSSTDESC/gcr-catalogs#available-catalogs">List of available catalogs</a> (that can be accessed by DESCQA), including a brief description of each catalog</li>
+  <li><a class="everblue" href="https://github.com/LSSTDESC/descqa/tree/master/descqa/configs">List of available DESCQA tests</a> (each yaml file has a "description" field)</li>
   <li><a class="everblue" href="https://confluence.slac.stanford.edu/display/LSSTDESC/DC2+Data+Product+Overview">DC2 Data Product Overview</a> (confluence log-in required)</a></li>
 </ul>
 

--- a/descqaweb/templates/home.html
+++ b/descqaweb/templates/home.html
@@ -1,10 +1,11 @@
 <div class="homeinfo">
 <h3>{{ general_info }}
+<br><br>
 
-<span class="darkred">Apologies! We are in the process of revamping this front page!</span>
-You can <a href="https://github.com/LSSTDESC/descqa/issues/160">comment here</a> if you want to contribute your ideas.<br><br>
+<span style="color:red;">Apologies! We are in the process of revamping this front page!</span><br>
+If you have ideas to contribute, please comment in <a class="everblue" href="https://github.com/LSSTDESC/descqa/issues/160">LSSTDESC/descqa#160</a>.<br><br>
 
-In the meantime, if you are looking for results from specific catalogs/tests, <br>
+In the meantime, if you are looking for results from specific catalogs or tests,
 you can use the search features in the <a class="everblue" href="?run=all">list of all runs</a>.<br>
 Here are a few examples:<br>
 <ul>

--- a/descqaweb/templates/home.html
+++ b/descqaweb/templates/home.html
@@ -3,17 +3,10 @@
 <br><br>
 
 <span style="color:red;">Apologies! We are in the process of revamping this front page!</span><br>
-<<<<<<< HEAD
 If you have ideas to contribute, please comment in <a class="everblue" href="https://github.com/LSSTDESC/descqa/issues/160">LSSTDESC/descqa#160</a>.<br><br>
 
 In the meantime, if you are looking for results from specific catalogs or tests,
 you can use the search features in the <a class="everblue" href="?run=all">list of all runs</a>.<br>
-=======
-If you have ideas to contribute, please comment in <a class="everblue" href="https://github.com/LSSTDESC/descqa/issues/160">LSSTDESC/descqa#160"</a><br><br>
-
-In the meantime, if you are looking for results from specific catalogs/tests,
-you can use the search features in the <a class="everblue" href="?run=all">list of all runs</a>.
->>>>>>> f932839ebb1525ad7538afb8d20ac6f1650f140a
 Here are a few examples:<br>
 <ul>
 <li><a class="everblue" href="?users=kovacs&catalogs=cosmoDC2_v1.1.4&run=all&months=6">cosmoDC2 v1.1.4 (for Run 2.1)</a></li>

--- a/descqaweb/templates/home.html
+++ b/descqaweb/templates/home.html
@@ -1,0 +1,19 @@
+<div class="homeinfo">
+<h3>{{ general_info }}
+
+<span class="darkred">Apologies! We are in the process of revamping this front page!</span>
+You can <a href="https://github.com/LSSTDESC/descqa/issues/160">comment here</a> if you want to contribute your ideas.<br><br>
+
+In the meantime, if you are looking for results from specific catalogs/tests, <br>
+you can use the search features in the <a class="everblue" href="?run=all">list of all runs</a>.<br>
+Here are a few examples:<br>
+<ul>
+<li><a class="everblue" href="?users=kovacs&catalogs=cosmoDC2_v1.1.4&run=all&months=6">cosmoDC2 v1.1.4 (for Run 2.1)</a></li>
+<li><a class="everblue" href="?users=kovacs&catalogs=cosmoDC2_v1.0&run=all&months=6">cosmoDC2 v1.0 (for Run 2.0)</a></li>
+<li><a class="everblue" href="?users=kovacs&catalogs=proto-dc2_v3.0&run=all&months=12">protoDC2 v3.0 (for Run 1.2)</a></li>
+<li><a class="everblue" href="?users=kovacs&catalogs=proto-dc2_v2.1.2&run=all&months=12">protoDC2 v2.1.2 (for Run 1.1)</a></li>
+</ul>
+</h3>
+<script>document.getElementById("pleasewait").style.display="none";</script>
+</body>
+</html>

--- a/descqaweb/templates/home.html
+++ b/descqaweb/templates/home.html
@@ -14,6 +14,15 @@ Here are a few examples:<br>
 <li><a class="everblue" href="?users=kovacs&catalogs=proto-dc2_v3.0&run=all&months=12">protoDC2 v3.0 (for Run 1.2)</a></li>
 <li><a class="everblue" href="?users=kovacs&catalogs=proto-dc2_v2.1.2&run=all&months=12">protoDC2 v2.1.2 (for Run 1.1)</a></li>
 </ul>
+<br>
+
+When navigating the DESCQA tests, you may find the following links useful:<br>
+<ul>
+  <li><a class="everblue" href="https://github.com/LSSTDESC/gcr-catalogs#available-catalogs">List of available catalogs</a> (that can be accessed by DESCQA), including a brief description of each catalog.</li>
+  <li><a class="everblue" href="https://github.com/LSSTDESC/descqa/tree/master/descqa/configs">List of available DESCQA tests</a> (each yaml file has a "description" field).</li>
+  <li><a class="everblue" href="https://confluence.slac.stanford.edu/display/LSSTDESC/DC2+Data+Product+Overview">DC2 Data Product Overview</a> (confluence log-in required)</a></li>
+</ul>
+
 </h3>
 <script>document.getElementById("pleasewait").style.display="none";</script>
 </body>


### PR DESCRIPTION
As discussed in #160, the current front page is very outdated. Before we come up with a more permanent solution, we should put something more informative on the front page. This PR makes a quick update to the front page.

You can preview this PR here: https://portal.nersc.gov/project/lsst/descqa/v2-new-home/