### PR TITLE
Update HTML header/meta of DESCQA website

### DIFF
--- a/descqaweb/templates/header.html
+++ b/descqaweb/templates/header.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<title>{{ config.site_title }}</title>
-<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css">
+<title>{{ config.site_title }}</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
 <link rel="stylesheet" href="{{ config.static_dir }}/style.css">
 </head>
 


### PR DESCRIPTION
This PR updates the HTML header/meta of the DESCQA website to make them follow the new HTML5 standard and also update normalize css version. 