### PR TITLE
color distribution for snapshot catalogs

### DIFF
--- a/descqa/configs/Color_Dist_rest_snapshot.yaml
+++ b/descqa/configs/Color_Dist_rest_snapshot.yaml
@@ -1,0 +1,8 @@
+subclass_name: ColorDistribution.ColorDistribution
+Mag_r_limit: -19.0
+rest_frame: true
+lightcone: false
+plot_pdf_q: true
+plot_cdf_q: false
+color_transformation_q: false
+description: Inspect the mock-galaxy snapshot rest-frame color distributions


### PR DESCRIPTION
Here are the code modifications so that the Color distribution test will run on the baseDC2 snapshots (uses the new snapshot reader) Here is a test result: ( https://portal.nersc.gov/project/lsst/descqa/v2/?run=2019-04-23&catalog=baseDC2_snapshot_z0.15_v0.1)
Yao, I accidentally committed the same code to master, but it didn't get pushed. Sorry, I'm not sure how to clean that up.