### PR TITLE
move dependency link to regular requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install: # camb requires gfortran to be at least gfortran-6
 - sudo ln -s /usr/bin/gfortran-8 /usr/bin/gfortran
 
 install:
-- pip install --process-dependency-links .[full]
+- pip install .[full]
 - pip install pylint nose
 
 before_script:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=['future', 'pyyaml', 'jinja2'],
     extras_require={
         'full': ['numpy', 'scipy', 'matplotlib', 'GCR>=0.8.7', 'healpy', 'treecorr', 'camb', 'scikit-learn', 
-                 'CatalogMatcher @ https://github.com/LSSTDESC/CatalogMatcher.git'],
+                 'CatalogMatcher @ https://github.com/LSSTDESC/CatalogMatcher/archive/master.zip'],
     },
     package_data={'descqa': ['configs/*.yaml', 'data/*']},
 )

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ setup(
     packages=['descqa'],
     install_requires=['future', 'pyyaml', 'jinja2'],
     extras_require={
-        'full': ['numpy', 'scipy', 'matplotlib', 'GCR>=0.8.7', 'healpy', 'treecorr', 'camb', 'scikit-learn', 'CatalogMatcher'],
+        'full': ['numpy', 'scipy', 'matplotlib', 'GCR>=0.8.7', 'healpy', 'treecorr', 'camb', 'scikit-learn', 'CatalogMatcher @ https://github.com/LSSTDESC/CatalogMatcher.git@master'],
     },
-    dependency_links=[
-        'https://github.com/LSSTDESC/CatalogMatcher/archive/master.zip#egg=CatalogMatcher-0.1.0.dev',
-    ],
     package_data={'descqa': ['configs/*.yaml', 'data/*']},
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     packages=['descqa'],
     install_requires=['future', 'pyyaml', 'jinja2'],
     extras_require={
-        'full': ['numpy', 'scipy', 'matplotlib', 'GCR>=0.8.7', 'healpy', 'treecorr', 'camb', 'scikit-learn', 'CatalogMatcher @ https://github.com/LSSTDESC/CatalogMatcher.git@master'],
+        'full': ['numpy', 'scipy', 'matplotlib', 'GCR>=0.8.7', 'healpy', 'treecorr', 'camb', 'scikit-learn', 
+                 'CatalogMatcher @ https://github.com/LSSTDESC/CatalogMatcher.git'],
     },
     package_data={'descqa': ['configs/*.yaml', 'data/*']},
 )


### PR DESCRIPTION
pip v19 has deprecated `--process-dependency-links` and our CI test will not run. This PR fixes this issue by moving dependency links to regular requirements. 