### PR TITLE
Units fixes for EmissionlineRatioTest

### DIFF
--- a/descqa/EmlineRatioTest.py
+++ b/descqa/EmlineRatioTest.py
@@ -107,7 +107,6 @@ class EmlineRatioTest(BaseValidationTest):
                                                 'mag_i_lsst',
                                                 'mag_z_lsst',
                                                 'mag_y_lsst',
-                                                'galaxyID',
                                                 'emissionLines/totalLineLuminosity:oxygenII3726',
                                                 'emissionLines/totalLineLuminosity:oxygenII3729',
                                                 'redshift',
@@ -128,8 +127,7 @@ class EmlineRatioTest(BaseValidationTest):
         yband_maglim = GCRQuery((np.isfinite, 'mag_y_lsst'), 'mag_y_lsst < %.1f' % self.mag_y_cut)
 
 
-        data = catalog_instance.get_quantities(['galaxyID',
-                                                'emissionLines/totalLineLuminosity:oxygenII3726',
+        data = catalog_instance.get_quantities(['emissionLines/totalLineLuminosity:oxygenII3726',
                                                 'emissionLines/totalLineLuminosity:oxygenII3729',
                                                 'redshift',
                                                 'emissionLines/totalLineLuminosity:balmerAlpha6563',
@@ -145,8 +143,6 @@ class EmlineRatioTest(BaseValidationTest):
                                                 'mag_i_lsst',
                                                 'mag_z_lsst',
                                                 'mag_y_lsst'], filters=(uband_maglim | gband_maglim | rband_maglim | iband_maglim | zband_maglim | yband_maglim))
-        sz = data['redshift']
-        galaxyID = data['galaxyID']
 
         Halpha = (data['emissionLines/totalLineLuminosity:balmerAlpha6563'] * 3.839e26*u.W).value
         Hbeta = (data['emissionLines/totalLineLuminosity:balmerBeta4861'] * 3.839e26*u.W).value
@@ -165,7 +161,6 @@ class EmlineRatioTest(BaseValidationTest):
 
         indices = np.random.choice(np.arange(len(Halpha)), size=self.sim_drawnum, replace=False)
 
-        self.id = galaxyID[indices]
         self.ha = Halpha[indices]
         self.hb = Hbeta[indices]
         self.oii = OIItot[indices]

--- a/descqa/EmlineRatioTest.py
+++ b/descqa/EmlineRatioTest.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals, absolute_import, division
 import os
 import numpy as np
 from astropy import units as u
+from astropy.cosmology import Planck15 as cosmo
 from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 from GCR import GCRQuery
@@ -166,19 +167,19 @@ class EmlineRatioTest(BaseValidationTest):
         sz_small = sz[indices]
         galaxyID_small = galaxyID[indices]
 
-        self.id = galaxyID_small
-        self.ha = Halpha_small
-        self.hb = Hbeta_small
-        self.oii = OIItot_small
-        self.oiii = OIIItot_small
-        self.nii6584 = NII6584_small
-        self.oiii5007 = OIII5007_small
-        self.oiii4959 = OIII4959_small
-        self.oii3726 = OII3726_small
-        self.oii3729 = OII3729_small
-        self.sii6716 = SII6716_small
-        self.sii6731 = SII6731_small
-        self.siitot = SIItot_small
+        self.id = galaxyID[indices]
+        self.ha = Halpha[indices]
+        self.hb = Hbeta[indices]
+        self.oii = OIItot[indices]
+        self.oiii = OIIItot[indices]
+        self.nii6584 = NII6584[indices]
+        self.oiii5007 = OIII5007[indices]
+        self.oiii4959 = OIII4959[indices]
+        self.oii3726 = OII3726[indices]
+        self.oii3729 = OII3729[indices]
+        self.sii6716 = SII6716[indices]
+        self.sii6731 = SII6731[indices]
+        self.siitot = SIItot[indices]
 
 
         #=========================================

--- a/descqa/EmlineRatioTest.py
+++ b/descqa/EmlineRatioTest.py
@@ -67,9 +67,9 @@ class EmlineRatioTest(BaseValidationTest):
         self.kwargs = kwargs
         self.emline_ratio1 = kwargs.get('emline_ratio1', 'oii/oiii') # Currently does not support other emission line ratios
         self.emline_ratio2 = kwargs.get('emline_ratio2', 'hb/oiii') # Currently does not support other emission line ratios
-        sdss_file = kwargs.get('sdss_file', 'sdss_emission_lines/sdss_query_snr10_ew.csv')
+        sdss_file = kwargs.get('sdss_file', 'descqa/data/sdss_emission_lines/sdss_query_snr10_ew.csv')
         # self.sdsscat = sdsscat(self.data_dir + '/' + sdss_file)
-        self.sdsscat = sdsscat('descqa/data/' + sdss_file)
+        self.sdsscat = sdsscat(sdss_file)
 
         # The magnitude cuts for galaxies pulled from the catalog.  These numbers correspond to
         # a 5-sigma cut based on https://arxiv.org/pdf/0912.0201.pdf

--- a/descqa/EmlineRatioTest.py
+++ b/descqa/EmlineRatioTest.py
@@ -165,9 +165,6 @@ class EmlineRatioTest(BaseValidationTest):
 
         indices = np.random.choice(np.arange(len(Halpha)), size=self.sim_drawnum, replace=False)
 
-        sz_small = sz[indices]
-        galaxyID_small = galaxyID[indices]
-
         self.id = galaxyID[indices]
         self.ha = Halpha[indices]
         self.hb = Hbeta[indices]

--- a/descqa/configs/EmlineLuminosityRatios.yaml
+++ b/descqa/configs/EmlineLuminosityRatios.yaml
@@ -1,7 +1,7 @@
 subclass_name: EmlineRatioTest.EmlineRatioTest
 emline_ratio1: 'oii/oiii'
 emline_ratio2: 'hb/oiii'
-sdss_file: 'sdss_emission_lines/sdss_query_snr10_ew.csv'
+sdss_file: 'descqa/data/sdss_emission_lines/sdss_query_snr10_ew.csv'
 sdss_drawnum: 30000
 sim_drawnum: 30000
 mag_u_cut: 26.3


### PR DESCRIPTION
No changes to validation test content, but I have simplified the code so that it no longer converts emission line luminosities to fluxes before performing the test.