### PR TITLE
Add ability to filter catalog before running readiness test

### DIFF
--- a/descqa/configs/readiness_baseDC2_sm_cut.yaml
+++ b/descqa/configs/readiness_baseDC2_sm_cut.yaml
@@ -1,0 +1,124 @@
+subclass_name: readiness_test.CheckQuantities
+description: 'Plot histograms of listed quantities and perform range, finiteness, mean and standard deviation checks.'
+included_by_default: true
+
+catalog_filters:
+  - quantity: 'obs_sm'
+    label: 'M*'
+    min: 1e7
+
+quantities_to_check:
+  - quantities: ['dec_true', 'dec']
+    label: 'deg'
+    min: [-55, -54]
+    max: [-20, -19]
+    median: [-38, -34]
+    mean: [-38, -34]
+    std: [5, 10]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: ['ra_true', 'ra']
+    label: 'deg'
+    min: [39, 40]
+    max: [84, 85]
+    median: [60, 64]
+    mean: [60, 64]
+    std: [8, 12]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: ['redshift_true', 'redshift']
+    label: redshift
+    min: [-0.05, 0.05]
+    max: [2.95, 3.05]
+    median: [1.8, 2.2]
+    mean: [1.8, 2.2]
+    std: [0.6, 0.7]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.001]
+
+  - quantities: 'velocity_*'
+    label: velocity
+    min: [-10500., -9500.]
+    max: [9500., 10500.]
+    median: [-100., 100.]
+    mean: [-100., 100.]
+    std: [200., 600.]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.1]
+
+  - quantities: 'shear_*'
+    min: [-0.25, 0]
+    max: [0, 0.25]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.02]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.04]
+
+  - quantities: 'position_angle*'
+    min: [0, 0.001]
+    max: [179.99, 180]
+    median: [89.9, 90.1]
+    mean: [89.9, 90.1]
+    std: [0, 90.0]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: 0
+
+  - quantities: 'convergence'
+    min: [-0.4, 0]
+    max: [0, 0.8]
+    median: [-0.01, 0.01]
+    mean: [-0.01, 0.01]
+    std: [0, 0.03]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'magnification'
+    min: [0.5, 1]
+    max: [1, 20]
+    median: [0.5, 1.5]
+    mean: [0.5, 1.5]
+    std: [0, 0.1]
+    f_nan: 0
+    f_inf: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'Mag_*lsst*'
+    label: Mag
+    min: [null, -23]
+    max: [-12, null]
+    mean: [-17, -8]
+    median: [-17, -8]
+    std: [0, 5]
+    f_nan: 0
+    f_inf: 0
+    f_zero: 0
+    f_outlier: [0, 0.05]
+
+  - quantities: 'stellar_mass*'
+    log: true
+    min: [null, 10]
+    max: [10, 13]
+    median: [5.5, 7]
+    mean: [5.5, 7]
+    std: [0.5, 1.5]
+    f_nan: 0
+    f_outlier: [0, 0.025]
+
+relations_to_check:
+  - 'galaxy_id < 1e11'
+  - '1.0 / magnification ~== (1.0 - convergence)**2.0 - shear_1**2.0 - shear_2**2.0'
+
+uniqueness_to_check:
+  - quantity: galaxy_id
+  - quantity: halo_id
+    mask: is_central

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -107,7 +107,9 @@ class CheckQuantities(BaseValidationTest):
         self.quantities_to_check = kwargs.get('quantities_to_check', [])
         self.relations_to_check = kwargs.get('relations_to_check', [])
         self.uniqueness_to_check = kwargs.get('uniqueness_to_check', [])
-
+        self.catalog_filters = kwargs.get('catalog_filters', [])
+        self.lgndtitle_fontsize = kwargs.get('lgndtitle_fontsize', 12)
+        
         if not any((
                 self.quantities_to_check,
                 self.relations_to_check,
@@ -124,6 +126,12 @@ class CheckQuantities(BaseValidationTest):
         if not all(d.get('quantity') for d in self.uniqueness_to_check):
             raise ValueError('yaml file error: `quantity` must exist for each item in `uniqueness_to_check`')
 
+        if not all(d.get('quantity') for d in self.catalog_filters):
+            raise ValueError('yaml file error: `quantity` must exist for each item in `catalog_filters`')
+
+        if not all(d.get('min') for d in self.catalog_filters) or all(d.get('max') for d in self.catalog_filters):
+            raise ValueError('yaml file error: `min` or `max` must exist for each item in `catalog_filters`')
+        
         self.enable_individual_summary = bool(kwargs.get('enable_individual_summary', True))
         self.enable_aggregated_summary = bool(kwargs.get('enable_aggregated_summary', False))
         self.always_show_plot = bool(kwargs.get('always_show_plot', True))
@@ -223,6 +231,29 @@ class CheckQuantities(BaseValidationTest):
             individual_only=True,
         ))
 
+        # check filters
+        filters = []
+        filter_labels = ''
+        for d in self.catalog_filters:
+            fq = d.get('quantity')
+            if fq in all_quantities:
+                filter_label=''
+                qlabel = d.get('label') if d.get('label') else fq
+                if d.get('min') is not None:
+                    filters.append('{} >= {}'.format(fq, d.get('min')))
+                    filter_label = '{} <= {}'.format(d.get('min'), qlabel)
+                if d.get('max') is not None:
+                    filters.append('{} < {}'.format(fq, d.get('max')))
+                    flabel = '{} <= {}'.format(qlabel, d.get('max'))
+                    filter_label = flabel if len(filter_label)==0 else re.sub(str(d.get('label')), flabel, filter_label)
+                filter_labels = '$'+filter_label+'$' if len(filter_labels)==0 else ', '.join([filter_labels,
+                                                                                              '$'+filter_label+'$'])
+            else:
+                self.record_result('Found no matching quantity for filtering on {}'.format(fq), failed=True)
+                continue
+
+        print(filters, filter_labels)
+
         for i, checks in enumerate(self.quantities_to_check):
 
             quantity_patterns = checks['quantities'] if isinstance(checks['quantities'], (tuple, list)) else [checks['quantities']]
@@ -248,7 +279,11 @@ class CheckQuantities(BaseValidationTest):
             has_plot = False
 
             for quantity in quantities_this:
-                value = catalog_instance[quantity]
+                if len(filters) > 0:
+                    catalog_data = catalog_instance.get_quantities([quantity], filters=filters)
+                    value = catalog_data[quantity]
+                else:
+                    value = catalog_instance[quantity]
                 need_plot = False
 
                 if galaxy_count is None:
@@ -314,7 +349,8 @@ class CheckQuantities(BaseValidationTest):
                 ax.set_title('{} {}'.format(catalog_name, getattr(catalog_instance, 'version', '')), fontsize='small')
                 fig.tight_layout()
                 if len(quantities_this) <= 9:
-                    leg = ax.legend(loc='best', fontsize='x-small', ncol=3, frameon=True, facecolor='white')
+                    leg = ax.legend(loc='best', fontsize='x-small', ncol=3, frameon=True, facecolor='white',
+                                    title=filter_labels, title_fontsize=self.lgndtitle_fontsize)
                     leg.get_frame().set_alpha(0.5)
                 fig.savefig(os.path.join(output_dir, plot_filename))
             plt.close(fig)

--- a/descqa/readiness_test.py
+++ b/descqa/readiness_test.py
@@ -108,7 +108,7 @@ class CheckQuantities(BaseValidationTest):
         self.relations_to_check = kwargs.get('relations_to_check', [])
         self.uniqueness_to_check = kwargs.get('uniqueness_to_check', [])
         self.catalog_filters = kwargs.get('catalog_filters', [])
-        self.lgndtitle_fontsize = kwargs.get('lgndtitle_fontsize', 12)
+        self.lgndtitle_fontsize = kwargs.get('lgndtitle_fontsize', 10)
         
         if not any((
                 self.quantities_to_check,


### PR DESCRIPTION
> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 
This addition allows a filter to be applied to the catalog data before running the readiness tests. This was useful for testing the new baseDC2_5000 against the old catalog. baseDC2_5000 has a stellar-mass cut applied, which reduces the number of synthetic galaxies. I wanted to apply the same cut to the old baseDC2 catalog to do a comparison. The cosmic variance of the redshift distribution was of particular interest. Here's an [example run for healpixel 9556](https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2020-05-01_10&test=readiness_baseDC2_sm_cut)