### PR TITLE
Update linter arguments in CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Cache Python packages
       uses: actions/cache@v1
       with:
@@ -36,16 +36,13 @@ jobs:
       run: |
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 descqa* tests --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 descqa descqagen descqaweb descqarun tests --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 descqa* tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 descqa descqagen descqaweb descqarun tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Lint with pylint
       run: |
         pip install pylint
-        # stop the build if there are Pylint errors
-        # there is a bug with E1136 (https://github.com/PyCQA/pylint/issues/1498)
-        # so we temporarily disable it.
-        pylint --disable=I,C,R,W0511,W0231,E1136 --extension-pkg-whitelist=numpy descqa*
+        pylint --disable=all --enable=F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode --extension-pkg-whitelist=numpy descqa descqagen descqaweb descqarun
     - name: Test with pytest
       run: |
         pip install pytest


### PR DESCRIPTION
This PR updates the linter arguments in the CI test to avoid CI test failures due to unnecessary linter complaints. 