### PR TITLE
Dc2 paper

### DIFF
--- a/descqa/ColorDistribution.py
+++ b/descqa/ColorDistribution.py
@@ -64,6 +64,7 @@ class ColorDistribution(BaseValidationTest):
         self.exclude_agn = kwargs.get('exclude_agn', False)
         self.plot_shift = kwargs.get('plot_shift', True)
         self.truncate_cat_name = kwargs.get('truncate_cat_name', False)
+        self.replace_cat_name = kwargs.get('replace_cat_name', {})
         self.title_in_legend = kwargs.get('title_in_legend', False)
         self.legend_location = kwargs.get('legend_location', 'upper left')
         self.skip_statistic = kwargs.get('skip_statistic', False)
@@ -288,11 +289,9 @@ class ColorDistribution(BaseValidationTest):
             if self.truncate_cat_name:
                 catalog_name = re.split('_', catalog_name)[0]
                 spacing = ', '
-            elif self.shorten_cat_name: #remove some typical qualifiers
-                for q in ['small', 'image', 'object', 'matched', 'addon']:
-                    catalog_name = re.sub(q, '', catalog_name)
-                catalog_name = re.sub('_+', '_', catalog_name)
-                catalog_name = re.sub('_$', '', catalog_name)
+            if self.replace_cat_name:
+                for k, v in self.replace_cat_name.items():
+                    catalog_name = re.sub(k, v, catalog_name)
                 
             if cvm_omega.get(color, None) and not self.skip_statistic:
                 catalog_label = catalog_name + spacing + r'$\omega={:.3}$'.format(cvm_omega[color])

--- a/descqa/ColorDistribution.py
+++ b/descqa/ColorDistribution.py
@@ -69,7 +69,8 @@ class ColorDistribution(BaseValidationTest):
         self.skip_statistic = kwargs.get('skip_statistic', False)
         self.font_size = kwargs.get('font_size', 16)
         self.legend_size = kwargs.get('legend_size', 10)
-
+        self.shorten_cat_name = kwargs.get('shorten_cat_name', True)
+        
         # bins of color distribution
         self.bins = np.linspace(-1, 4, 2000)
         self.binsize = self.bins[1] - self.bins[0]
@@ -77,7 +78,8 @@ class ColorDistribution(BaseValidationTest):
         # Load validation catalog and define catalog-specific properties
         self.sdss_path = os.path.join(self.external_data_dir, 'rongpu', 'SpecPhoto_sdss_mgs_extinction_corrected.fits')
         self.deep2_path = os.path.join(self.external_data_dir, 'rongpu', 'DEEP2_uniq_Terapix_Subaru_trimmed_wights_added.fits')
-
+        
+        # Load validation catalog and define catalog-specific properties
         if self.validation_catalog == 'SDSS':
             obs_path = self.sdss_path
             obscat = Table.read(obs_path)
@@ -124,7 +126,7 @@ class ColorDistribution(BaseValidationTest):
             possible_names = ('Mag_{}_lsst', 'Mag_{}_sdss', 'Mag_true_{}_lsst_z0', 'Mag_true_{}_sdss_z0')
         else:
             possible_lsst_names = (('mag_{}_noagn_lsst', 'mag_true_{}_noagn_lsst')
-                                   if self.exclude_agn else ('mag_{}_lsst', 'mag_true_{}_lsst'))
+                                   if self.exclude_agn else ('mag_{}_cModel', 'mag_{}_lsst', 'mag_true_{}_lsst'))
             possible_non_lsst_names = ('mag_{}_sdss', 'mag_{}_des', 'mag_true_{}_sdss', 'mag_true_{}_des')
             if self.use_lsst:
                 print('Selecting lsst magnitudes if available')
@@ -144,7 +146,7 @@ class ColorDistribution(BaseValidationTest):
         filter_this = filters.pop()
 
         if self.lightcone:
-            labels['redshift'] = catalog_instance.first_available('redshift_true', 'redshift')
+            labels['redshift'] = catalog_instance.first_available('redshift_true_galaxy', 'redshift_true', 'redshift')
             if not labels['redshift']:
                 return TestResult(skipped=True, summary='mock catalog does not have redshift.')
 
@@ -156,13 +158,18 @@ class ColorDistribution(BaseValidationTest):
             redshift = catalog_instance.redshift
 
         data = catalog_instance.get_quantities(list(labels.values()), filters)
-        data = {k: data[v] for k, v in labels.items()}
+        # filter catalog data further for matched object catalogs 
+        if np.ma.isMaskedArray(data[labels['redshift']]):
+            galmask = np.ma.getmask(data[labels['redshift']])
+            data = {k:data[v][galmask] for k, v in labels.items()}
+        else:
+            data = {k: data[v] for k, v in labels.items()}
 
         # Color transformation
         color_trans = None
         if self.color_transformation_q:
             color_trans_name = None
-            if self.validation_catalog == 'DEEP2' and filter_this != 'lsst':
+            if self.validation_catalog == 'DEEP2' and (filter_this == 'sdss' or filter_this == 'des'):
                 color_trans_name = '{}2cfht'.format(filter_this)
             elif self.validation_catalog == 'SDSS' and filter_this == 'des':
                 color_trans_name = 'des2sdss'
@@ -281,6 +288,12 @@ class ColorDistribution(BaseValidationTest):
             if self.truncate_cat_name:
                 catalog_name = re.split('_', catalog_name)[0]
                 spacing = ', '
+            elif self.shorten_cat_name: #remove some typical qualifiers
+                for q in ['small', 'image', 'object', 'matched', 'addon']:
+                    catalog_name = re.sub(q, '', catalog_name)
+                catalog_name = re.sub('_+', '_', catalog_name)
+                catalog_name = re.sub('_$', '', catalog_name)
+                
             if cvm_omega.get(color, None) and not self.skip_statistic:
                 catalog_label = catalog_name + spacing + r'$\omega={:.3}$'.format(cvm_omega[color])
             else:

--- a/descqa/NumberDensityVersusRedshift.py
+++ b/descqa/NumberDensityVersusRedshift.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, unicode_literals, absolute_import
 import os
 import math
+import re
 try:
     from itertools import zip_longest
 except ImportError:
@@ -51,7 +52,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         number of jackknife regions
         `N_jack` should be much larger than `N_zbins` for the jackknife errors to be stable
     ra : str, optional, (default: 'ra')
-        label of RA column (used if `jackknife` is `True`)    
+        label of RA column (used if `jackknife` is `True`)
     dec : str, optional, (default: 'dec')
         label of Dec column (used if `jackknife` is `True`)
     pass_limit : float, optional (default: 2.)
@@ -91,8 +92,6 @@ class NumberDensityVersusRedshift(BaseValidationTest):
     figx_p = 9
     figy_p = 11
     lw2 = 2
-    fsize = 16 #fontsize
-    lsize = 10 #legendsize
     msize = 6  #markersize
     default_colors = ['blue', 'r', 'm', 'g', 'navy', 'y', 'purple', 'gray', 'c',\
         'orange', 'violet', 'coral', 'gold', 'orchid', 'maroon', 'tomato', \
@@ -100,14 +99,20 @@ class NumberDensityVersusRedshift(BaseValidationTest):
     validation_color = 'black'
     default_markers = ['o', 'v', 's', 'd', 'H', '^', 'D', 'h', '<', '>', '.']
 
-    def __init__(self, z='redshift_true', band='i', N_zbins=10, zlo=0., zhi=1.1,
+    def __init__(self, band='i', N_zbins=10, zlo=0., zhi=1.1,
                  observation='', mag_lo=27, mag_hi=18, ncolumns=2, normed=True,
-                 jackknife=False, N_jack=20, ra='ra', dec='dec', pass_limit=2., 
+                 jackknife=False, N_jack=20, ra='ra', dec='dec', pass_limit=2.,
                  use_diagonal_only=False, rest_frame=False, **kwargs):
         # pylint: disable=W0231
 
         #catalog quantities
-        self.zlabel = z
+        self.truncate_cat_name = kwargs.get('truncate_cat_name', False)
+        self.shorten_cat_name = kwargs.get('shorten_cat_name', True)
+        self.title_in_legend = kwargs.get('title_in_legend', False)
+        self.legend_location = kwargs.get('legend_location', 'upper left')
+        self.font_size = kwargs.get('font_size', 16)
+        self.legend_size = kwargs.get('legend_size', 10)
+        self.tick_size = kwargs.get('tick_size', 12)
         self.rest_frame = rest_frame
         if self.rest_frame:
             possible_mag_fields = ('Mag_true_{}_lsst_z0',
@@ -115,7 +120,8 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                                    'Mag_true_{}_des_z0',
                                   )
         else:
-            possible_mag_fields = ('mag_{}_lsst',
+            possible_mag_fields = ('mag_{}_cModel',
+                                   'mag_{}_lsst',
                                    'mag_{}_sdss',
                                    'mag_{}_des',
                                    'mag_true_{}_lsst',
@@ -123,6 +129,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                                    'mag_true_{}_des',
                                   )
         self.possible_mag_fields = [f.format(band) for f in possible_mag_fields]
+        self.possible_redshifts = ['redshift_true_galaxy', 'redshift_true']
         self.band = band
 
         #z-bounds and binning
@@ -130,7 +137,6 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         self.zhi = zhi
         self.N_zbins = N_zbins
         self.zbins = np.linspace(zlo, zhi, N_zbins+1)
-        self.filters = [(lambda z: (z > zlo) & (z < zhi), self.zlabel)]
 
         #errors
         self.jackknife = jackknife
@@ -174,6 +180,19 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         #get magnitude cuts based on validation data or default limits (only catalog data plotted)
         mag_lo = self.validation_data.get('mag_lo', [float(m) for m in range(int(mhi), int(mlo+1))])
         mag_hi = self.validation_data.get('mag_hi', [])
+        print(mag_lo, mag_hi)
+        #check if supplied limits differ from validation limits and adjust
+        mask = (mag_lo <= float(mlo)) & (mag_lo >= float(mhi))
+        if np.count_nonzero(mask) < len(mag_lo):
+            if len(mag_hi) > 0:
+                mag_hi = mag_hi[mask]
+                self.validation_data['mag_hi'] = mag_hi
+            mag_lo = mag_lo[mask]
+            self.validation_data['mag_lo'] = mag_lo
+            if 'z0values' in self.validation_data:
+                self.validation_data['z0values'] = self.validation_data['z0values'][mask]
+            if  'z0errors' in self.validation_data:
+                self.validation_data['z0errors'] = self.validation_data['z0errors'][mask]
 
         #setup number of plots and number of rows required for subplots
         self.nplots = len(mag_lo)
@@ -205,7 +224,8 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         #set mag_lo and mag_hi for cases where range of magnitudes is given
         if 'mag_lo' not in validation_data:
             validation_data['mag_hi'] = []
-            validation_data['mag_lo'] = [float(m) for m in range(int(validation_data['mag_hi_lim']), int(validation_data['mag_lo_lim'])+1)]
+            validation_data['mag_lo'] = np.asarray([float(m) for m in range(int(validation_data['mag_hi_lim']),
+                                                                            int(validation_data['mag_lo_lim'])+1)])
 
         return validation_data
 
@@ -215,6 +235,11 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         mag_field = catalog_instance.first_available(*self.possible_mag_fields)
         if not mag_field:
             return TestResult(skipped=True, summary='Missing required mag_field option')
+        self.zlabel = catalog_instance.first_available(*self.possible_redshifts)
+        if not self.zlabel:
+            return TestResult(skipped=True, summary='Missing required redhsift option')
+        self.filters = [(lambda z: (z > self.zlo) & (z < self.zhi), self.zlabel)]
+
         jackknife_quantities = [self.zlabel, self.ra, self.dec] if self.jackknife else [self.zlabel]
         for jq in jackknife_quantities:
             if not catalog_instance.has_quantity(jq):
@@ -225,6 +250,14 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         filelabel = '_'.join((filtername, self.band))
 
         #setup plots
+        if self.truncate_cat_name:
+            catalog_name = re.split('_', catalog_name)[0]
+        elif self.shorten_cat_name: #remove some typical qualifiers
+            for q in ['small', 'image', 'object', 'matched', 'addon']:
+                catalog_name = re.sub(q, '', catalog_name)
+            catalog_name = re.sub('_+', '_', catalog_name)
+            catalog_name = re.sub('_$', '', catalog_name)
+                                                                                    
         fig, ax = plt.subplots(self.nrows, self.ncolumns, figsize=(self.figx_p, self.figy_p), sharex='col')
         catalog_color = next(self.colors)
         catalog_marker = next(self.markers)
@@ -237,6 +270,11 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         #get catalog data by looping over data iterator (needed for large catalogs) and aggregate histograms
         for catalog_data in catalog_instance.get_quantities(required_quantities, filters=self.filters, return_iterator=True):
             catalog_data = GCRQuery(*((np.isfinite, col) for col in catalog_data)).filter(catalog_data)
+            # filter catalog data further for matched object catalogs
+            if np.ma.isMaskedArray(catalog_data[self.zlabel]):
+                galmask = np.ma.getmask(catalog_data[self.zlabel])
+                catalog_data = {k: v[galmask] for k, v in catalog_data.items()}
+
             for n, (cut_lo, cut_hi, N, sumz) in enumerate(zip_longest(
                     self.mag_lo,
                     self.mag_hi,
@@ -276,13 +314,16 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                 self.validation_data.get('z0values', []),
                 self.validation_data.get('z0errors', []),
         )):
+
             if cut_lo is None:  #cut_lo is None if self.mag_lo is exhausted
-                ax_this.set_visible(False)
-                summary_ax_this.set_visible(False)
+                if ax_this is not None:
+                    ax_this.set_visible(False)
+                if summary_ax_this is not None:
+                    summary_ax_this.set_visible(False)
             else:
                 cut_label = '{} $< {}$'.format(self.band, cut_lo)
                 if cut_hi:
-                    cut_label = '${} <=$ {}'.format(cut_hi, cut_label) #also appears in txt file so don't use \leq
+                    cut_label = '${} \\leq $ {}'.format(cut_hi, cut_label) #also appears in txt file
 
                 if z0 is None and 'z0const' in self.validation_data:  #alternate format for some validation data
                     z0 = self.validation_data['z0const'] + self.validation_data['z0linear'] * cut_lo
@@ -308,7 +349,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                 #make subplot
                 catalog_label = ' '.join((catalog_name, cut_label.replace(self.band, filtername + ' ' + self.band)))
                 validation_label = ' '.join((self.validation_data.get('label', ''), cut_label))
-                key = cut_label.replace('$', '')
+                key = cut_label.replace('$', '').replace('\\leq', '<=')
                 results[key] = {'meanz': meanz, 'total':total, 'N':N, 'N+-':Nerrors}
                 self.catalog_subplot(ax_this, meanz, N, Nerrors, catalog_color, catalog_marker, catalog_label)
                 if z0 and z0 > 0: # has validation data
@@ -328,19 +369,21 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                 self.decorate_subplot(summary_ax_this, n)
 
         #save results for catalog and validation data in txt files
-        for filename, dtype, comment, info, info2 in zip_longest((filelabel, self.observation), ('N', 'fit'), (filtername,), ('total',), ('score',)):
+        for filename, dtype, comment, info, info2 in zip_longest((filelabel, self.observation), ('N', 'fit'),
+                                                                 (filtername,), ('total', 'z0'), ('score', 'z0err')):
             if filename:
                 with open(os.path.join(output_dir, 'Nvsz_' + filename + '.txt'), 'ab') as f_handle: #open file in append binary mode
                     #loop over magnitude cuts in results dict
                     for key, value in results.items():
-                        self.save_quantities(dtype, value, f_handle, comment=' '.join(((comment or ''), key, value.get(info, ''), value.get(info2, ''))))
-                
+                        self.save_quantities(dtype, value, f_handle, comment=' '.join(((comment or ''),
+                                                                                       key, value.get(info, ''), value.get(info2, ''))))
+
                 if self.jackknife:
                     with open(os.path.join(output_dir, 'Nvsz_' + filename + '.txt'), 'a') as f_handle: #open file in append mode
                         f_handle.write('\nInverse Covariance Matrices:\n')
                         for key in results.keys():
-                            self.save_matrix(results[key]['inverse_cov_matrix'], f_handle, comment= key)
-            
+                            self.save_matrix(results[key]['inverse_cov_matrix'], f_handle, comment=key)
+
 
         if self.first_pass: #turn off validation data plot in summary for remaining catalogs
             self.first_pass = False
@@ -359,7 +402,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
 
     def get_jackknife_errors(self, N_jack, jackknife_data, N):
         nn = np.stack((jackknife_data[self.ra], jackknife_data[self.dec]), axis=1)
-        _, jack_labels, _ = k_means(n_clusters=N_jack, random_state=0, X=nn, n_jobs=-1)
+        _, jack_labels, _ = k_means(n_clusters=N_jack, random_state=0, X=nn)
 
         #make histograms for jackknife regions
         Njack_array = np.zeros((N_jack, len(self.zbins)-1), dtype=np.int)
@@ -384,7 +427,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         ndata = meanz**2*np.exp(-meanz/z0)
         norm = self.nz_norm(self.zhi, z0) - self.nz_norm(self.zlo, z0)
         ax.plot(meanz, ndata/norm, label=validation_label, ls='--', color=self.validation_color, lw=self.lw2)
-        fits = {'fit': ndata/norm}
+        fits = {'fit': ndata/norm, 'z0':'z0 = {:.3f}'.format(z0)}
 
         if z0err and z0err > 0:
             nlo = meanz**2*np.exp(-meanz/(z0-z0err))
@@ -394,14 +437,16 @@ class NumberDensityVersusRedshift(BaseValidationTest):
             ax.fill_between(meanz, nlo/normlo, nhi/normhi, alpha=0.3, facecolor=self.validation_color)
             fits['fit+'] = nhi/normhi
             fits['fit-'] = nlo/normlo
+            fits['z0err'] = 'z0err = {:.3f}'.format(z0err)
 
         return fits
 
 
     def decorate_subplot(self, ax, nplot):
         #add axes and legend
+        ax.tick_params(labelsize=self.tick_size)
         if nplot % self.ncolumns == 0:  #1st column
-            ax.set_ylabel('$'+self.yaxis+'$', size=self.fsize)
+            ax.set_ylabel(self.yaxis, size=self.font_size)
 
         if nplot+1 <= self.nplots-self.ncolumns:  #x scales for last ncol plots only
             #print "noticks",nplot
@@ -410,11 +455,11 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                 #prevent overlapping yaxis labels
                 ax.yaxis.get_major_ticks()[0].label1.set_visible(False)
         else:
-            ax.set_xlabel('$z$', size=self.fsize)
+            ax.set_xlabel('z', size=self.font_size)
             ax.tick_params(labelbottom=True)
             for axlabel in ax.get_xticklabels():
                 axlabel.set_visible(True)
-        ax.legend(loc='best', fancybox=True, framealpha=0.5, fontsize=self.lsize, numpoints=1)
+        ax.legend(loc='best', fancybox=True, framealpha=0.5, fontsize=self.legend_size, numpoints=1)
 
 
     @staticmethod
@@ -427,7 +472,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
 
         catalog = catalog[mask]
         validation = validation[mask]
-        cov = cov[mask][:,mask]
+        cov = cov[mask][:, mask]
 
         inverse_cov = np.diag(1.0 / np.diag(cov))
         if not use_diagonal_only:

--- a/descqa/NumberDensityVersusRedshift.py
+++ b/descqa/NumberDensityVersusRedshift.py
@@ -107,7 +107,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
 
         #catalog quantities
         self.truncate_cat_name = kwargs.get('truncate_cat_name', False)
-        self.shorten_cat_name = kwargs.get('shorten_cat_name', True)
+        self.replace_cat_name = kwargs.get('replace_cat_name', {})
         self.title_in_legend = kwargs.get('title_in_legend', False)
         self.legend_location = kwargs.get('legend_location', 'upper left')
         self.font_size = kwargs.get('font_size', 16)
@@ -252,11 +252,9 @@ class NumberDensityVersusRedshift(BaseValidationTest):
         #setup plots
         if self.truncate_cat_name:
             catalog_name = re.split('_', catalog_name)[0]
-        elif self.shorten_cat_name: #remove some typical qualifiers
-            for q in ['small', 'image', 'object', 'matched', 'addon']:
-                catalog_name = re.sub(q, '', catalog_name)
-            catalog_name = re.sub('_+', '_', catalog_name)
-            catalog_name = re.sub('_$', '', catalog_name)
+        if self.replace_cat_name:
+            for k, v in self.replace_cat_name.items():
+                catalog_name = re.sub(k, v, catalog_name)
                                                                                     
         fig, ax = plt.subplots(self.nrows, self.ncolumns, figsize=(self.figx_p, self.figy_p), sharex='col')
         catalog_color = next(self.colors)

--- a/descqa/apparent_mag_func_test.py
+++ b/descqa/apparent_mag_func_test.py
@@ -51,7 +51,8 @@ class ApparentMagFuncTest(BaseValidationTest):
         self.x_lower_limit = kwargs.get('x_lower_limit', 15)
         self.print_title = kwargs.get('print_title', False)
         self.min_mag = kwargs.get('min_mag', 19.)
-
+        self.replace_cat_name = kwargs.get('replace_cat_name', {})
+        
         # catalog quantities needed
         possible_mag_fields = ('mag_{}_cModel',
                                'mag_{}_lsst',
@@ -205,6 +206,10 @@ class ApparentMagFuncTest(BaseValidationTest):
         # plot on both this plot and any summary plots
         if self.truncate_cat_name:
             catalog_name = re.split('_', catalog_name)[0]
+        if self.replace_cat_name:
+            for k, v in self.replace_cat_name.items():      
+                catalog_name = re.sub(k, v, catalog_name)
+                
         upper_ax.plot(mag_bins, sampled_N, '-', label=catalog_name + sky_area_label)
         self.summary_upper_ax.plot(mag_bins, sampled_N, '-', label=catalog_name + sky_area_label)
 

--- a/descqa/configs/ApparentMagFuncTest_HSCr_fig.yaml
+++ b/descqa/configs/ApparentMagFuncTest_HSCr_fig.yaml
@@ -1,0 +1,14 @@
+subclass_name: apparent_mag_func_test.ApparentMagFuncTest
+band: r
+band_lim: [24, 27.5]
+observation: 'HSC'
+included_by_default: true
+print_title: false
+x_lower_limit: 19
+truncate_cat_name: true
+font_size: 18
+legend_size: 12
+skip_label_detail: true
+replace_cat_name: {'dc2':'DC2'}
+
+description: 'Plot N(<mag) distributions for selected magnitude bounds in specified band and compare with extrpolated fits to HSC deep fields data.'

--- a/descqa/configs/Color_Dist_SDSS_with_LSST_fig.yaml
+++ b/descqa/configs/Color_Dist_SDSS_with_LSST_fig.yaml
@@ -7,5 +7,9 @@ use_lsst: true
 plot_pdf_q: true
 plot_cdf_q: false
 color_transformation_q: true
-shorten_cat_name: True
+truncate_cat_name: true
+replace_cat_name: {'dc2':'DC2'}
+legend_size: 12
+font_size: 18
+plot_shift: false
 description: Compare the mock galaxy color distribution with SDSS

--- a/descqa/configs/Color_Dist_SDSS_with_LSST_fig.yaml
+++ b/descqa/configs/Color_Dist_SDSS_with_LSST_fig.yaml
@@ -1,0 +1,11 @@
+subclass_name: ColorDistribution.ColorDistribution
+obs_r_mag_limit: 17.7
+zlo: 0.05
+zhi: 0.1
+validation_catalog: SDSS
+use_lsst: true
+plot_pdf_q: true
+plot_cdf_q: false
+color_transformation_q: true
+shorten_cat_name: True
+description: Compare the mock galaxy color distribution with SDSS

--- a/descqa/configs/Nz_r_DEEP2_JAN_fig.yaml
+++ b/descqa/configs/Nz_r_DEEP2_JAN_fig.yaml
@@ -1,0 +1,12 @@
+subclass_name: NumberDensityVersusRedshift.NumberDensityVersusRedshift
+band: r
+zlo: 0.
+zhi: 1.5
+N_zbins: 15
+observation: 'DEEP2_JAN'
+jackknife: True
+N_jack: 30
+shorten_cat_name: True
+use_diagonal_only: True
+included_by_default: true
+description: 'Plot N(z) distributions for selected magnitude cuts in specified band and compare with fits to DEEP2 data from J. A. Newman (priv. comm.)'

--- a/descqa/configs/Nz_r_DEEP2_JAN_fig.yaml
+++ b/descqa/configs/Nz_r_DEEP2_JAN_fig.yaml
@@ -6,7 +6,10 @@ N_zbins: 15
 observation: 'DEEP2_JAN'
 jackknife: True
 N_jack: 30
-shorten_cat_name: True
+truncate_cat_name: true
+replace_cat_name: {'dc2':'DC2'}
+legend_size: 12
+font_size: 18
 use_diagonal_only: True
 included_by_default: true
 description: 'Plot N(z) distributions for selected magnitude cuts in specified band and compare with fits to DEEP2 data from J. A. Newman (priv. comm.)'

--- a/descqa/configs/tpcf_Wang2013_rSDSS_DPDD.yaml
+++ b/descqa/configs/tpcf_Wang2013_rSDSS_DPDD.yaml
@@ -1,0 +1,67 @@
+subclass_name: CorrelationsTwoPoint.CorrelationsAngularTwoPoint
+
+# Catalog columns to attempt to load. The simplified names (e.g. ra, dec) are
+# the names that we be used to cut on in test_samples. Make sure these match.
+requested_columns:
+  ra:
+    - ra
+    - ra_true
+  dec:
+    - dec
+    - dec_true
+  mag:
+    - mag_r_sdss
+    - mag_r_des
+    - mag_r_lsst
+    - mag_true_r_sdss
+    - mag_true_r_des
+    - mag_true_r_lsst
+    - mag_r
+
+# Definition of samples and cuts to apply.  The names of these columns must
+# match the simple column name definitions above.
+test_samples:
+  r_17_18:
+    mag: {min: 17, max: 18}
+  r_18_19:
+    mag: {min: 18, max: 19}
+  r_19_20:
+    mag: {min: 19, max: 20}
+  r_20_21:
+    mag: {min: 20, max: 21}
+  r_17_21:
+    mag: {min: 17, max: 21}
+
+# Output file naming format for output of the resultant correlation values.
+output_filename_template: 'w_theta_r_{}.dat'
+
+# Name of file and columns to load and compare against the test samples.
+data_filename: 'tpcf/Wang_2013_MNRAS_stt450_Table2.txt'
+data_label: 'Y.Wang+2013'
+# Specify the columns to load from the data for comparison. The names here
+# should match the sample names from test_samples.
+test_data:
+  r_17_18: {data_col: 3, data_err_col: 4}
+  r_18_19: {data_col: 5, data_err_col: 6}
+  r_19_20: {data_col: 7, data_err_col: 8}
+  r_20_21: {data_col: 9, data_err_col: 10}
+  r_17_21: {data_col: 1, data_err_col: 2}
+
+# Plotting configuration.
+fig_xlabel: '$\theta\quad[{\rm deg}]}$'
+fig_ylabel: '$w(\theta)$'
+fig_ylim: [0.0001, 5.0]
+test_sample_labels:
+  r_17_18: '$17 < r < 18$'
+  r_18_19: '$18 < r < 19$'
+  r_19_20: '$19 < r < 20$'
+  r_20_21: '$20 < r < 21$'
+  r_17_21: '$17 < r < 21$'
+
+#Treecorr parameters
+min_sep: 0.01
+max_sep: 10
+bin_size: 0.25
+
+description: |
+  Compare angular correlation functions of catalog and Wang et al (2013) SDSS r-band observations


### PR DESCRIPTION
Minor updates to allow cosmetic changes to figures to be published in papers. Configuration files for figures used in DC2 paper. Examples of tests: [color distribution](https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2020-07-30_4&test=Color_Dist_SDSS_with_LSST_fig),  [dn/dmag](https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2020-07-28_5&test=ApparentMagFuncTest_HSCr_fig), [N(z) distribution](https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2020-07-30_2&test=Nz_r_DEEP2_JAN_fig)