### PR TITLE
Source DESC setup script directly in run_master.sh

### DIFF
--- a/run_master.sh
+++ b/run_master.sh
@@ -6,12 +6,8 @@
 # make sure all commands are executed
 set -e
 
-# load needed modules
-module load gsl
-module load cray-fftw
-
-# activate python env
-PYTHON="/global/common/software/lsst/common/miniconda/current/envs/desc/bin/python"
+# activate DESC python environment
+source /global/common/software/lsst/common/miniconda/setup_current_python.sh ""
 
 # set output directory
 OUTPUTDIR="/global/cfs/cdirs/lsst/groups/CS/descqa/run/v2"


### PR DESCRIPTION
OK, let's directly source DESC setup script directly in `run_master.sh` to avoid more troubles :slightly_smiling_face: 