### PR TITLE
Add redshift_truth option to run on dr2

### DIFF
--- a/descqa/NumberDensityVersusRedshift.py
+++ b/descqa/NumberDensityVersusRedshift.py
@@ -129,7 +129,7 @@ class NumberDensityVersusRedshift(BaseValidationTest):
                                    'mag_true_{}_des',
                                   )
         self.possible_mag_fields = [f.format(band) for f in possible_mag_fields]
-        self.possible_redshifts = ['redshift_true_galaxy', 'redshift_true']
+        self.possible_redshifts = ['redshift_true_galaxy', 'redshift_true', 'redshift_truth']
         self.band = band
 
         #z-bounds and binning


### PR DESCRIPTION
> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 
Here's a minor change I made to allow the code to run on the dr2 catalog.