### PR TITLE
Use `setup_old_python.sh`

### DIFF
--- a/run_master.sh
+++ b/run_master.sh
@@ -7,7 +7,7 @@
 set -e
 
 # activate DESC python environment
-source /global/common/software/lsst/common/miniconda/setup_current_python.sh ""
+source /global/common/software/lsst/common/miniconda/setup_old_python.sh ""
 PYTHON='python'
 
 # set output directory


### PR DESCRIPTION
DESCQA directly uses the python executable. For it to work with the new desc-python, DESCQA needs to be run within that shifter image. That wasn't expected in the original design.

For now I just switch to `setup_old_python.sh` in `run_master.sh` so that things should continue to work. We still need to find a long-term solution. 