### PR TITLE
point to desc-python rather than desc-python-old

### DIFF
--- a/run_master.sh
+++ b/run_master.sh
@@ -7,7 +7,7 @@
 set -e
 
 # activate DESC python environment
-source /global/common/software/lsst/common/miniconda/setup_old_python.sh ""
+source /global/common/software/lsst/common/miniconda/setup_current_python.sh ""
 PYTHON='python'
 
 # set output directory


### PR DESCRIPTION
Addresses #226 
Now that `desc-python` is again natively installed at NERSC, and `desc-python-old` is pointing to a shifter image, descqa needs to use `desc-python` as it was doing originally.
