### PR TITLE
Run full CI only when needed

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Get changed python files
+      id: changed_python_files
+      uses: tj-actions/changed-files@v20
+      with:
+        files: "*.py"
     - name: Cache Python packages
+      if: steps.changed_python_files.outputs.any_changed == 'true'
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
@@ -25,23 +31,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-py${{ matrix.python-version }}-pip-
     - name: Set up Python ${{ matrix.python-version }}
+      if: steps.changed_python_files.outputs.any_changed == 'true'
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install gfortran  # required by camb
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install gfortran -y
     - name: Install dependencies
+      if: steps.changed_python_files.outputs.any_changed == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install wheel
         pip install .[full]
-    - name: Get changed python files
-      id: changed_python_files
-      uses: tj-actions/changed-files@v20
-      with:
-        files: "*.py"
     - name: Lint with flake8
       if: steps.changed_python_files.outputs.any_changed == 'true'
       run: |
@@ -56,6 +55,7 @@ jobs:
         pip install pylint
         pylint --disable=all --enable=F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode --extension-pkg-whitelist=numpy ${{ steps.changed_python_files.outputs.all_changed_and_modified_files }}
     - name: Test with pytest
+      if: steps.changed_python_files.outputs.any_changed == 'true'
       run: |
         pip install pytest
         pytest


### PR DESCRIPTION
It took a long time to install all the python dependencies. The full CI run should be skipped if one just changes the README file. 