### PR TITLE
Nsevilla

### DIFF
--- a/descqa/srv_shear.py
+++ b/descqa/srv_shear.py
@@ -207,8 +207,8 @@ class CheckEllipticity(BaseValidationTest):
         plt.plot(bins_mid,e1residual_out,'b',label='e1-e1psf')
         plt.plot(bins_mid,e2residual_out,'r--',label='e2-e2psf')
         plt.title('e1/e2 residuals vs model, band '+band)
-        plt.savefig(os.path.join(output_dir, 'e1e2_residuals_'+band+'.png'))
         plt.legend()
+        plt.savefig(os.path.join(output_dir, 'e1e2_residuals_'+band+'.png'))
         plt.close()
         return
         
@@ -223,8 +223,8 @@ class CheckEllipticity(BaseValidationTest):
         self.record_result((0,'tfrac_residuals_'+band),'tfrac_residuals_'+band,'tfrac_residuals_'+band+'.png')
         plt.plot(bins_mid,tresidual_out,'b',label='(T-Tpsf)/Tpsf')
         plt.title('T fractional residuals vs model, band '+band)
-        plt.savefig(os.path.join(output_dir, 'tfrac_residuals_'+band+'.png'))
         plt.legend()
+        plt.savefig(os.path.join(output_dir, 'tfrac_residuals_'+band+'.png'))
         plt.close()
         return
     


### PR DESCRIPTION
> If you are submitting a PR for a validation test (either adding a new one or updating an existing one), please post a link to the DESCQA web interface for the test you are submitting. 

I have added two new types of plots to srv_shear. These correspond to additional plots that are in class TXPSFDiagnostics of the [psf_diagnostics.py of TXPipe](https://github.com/LSSTDESC/TXPipe/blob/master/txpipe/psf_diagnostics.py). 

I still see some weird behavior in some of the plots, TBC at a future update.

Also (disabled by now), starting adding the Rowe statistics functionality from class TXRoweStatistics on the same psf_diagnostics.py file.

Sample results:
https://[portal.nersc.gov/cfs/lsst/descqa/v2/?run=2023-01-23_4&test=srv_shear](https://portal.nersc.gov/cfs/lsst/descqa/v2/?run=2023-01-23_4&test=srv_shear)